### PR TITLE
Support resolving OpenFGA store id at runtime from store name

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/openfga/deployment/DevServicesOpenFGAProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/openfga/deployment/DevServicesOpenFGAProcessor.java
@@ -43,6 +43,7 @@ import io.quarkus.devservices.common.ContainerLocator;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.runtime.util.ClassPathUtils;
+import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.Vertx;
 
 public class DevServicesOpenFGAProcessor {
@@ -54,7 +55,7 @@ public class DevServicesOpenFGAProcessor {
     static final String DEV_SERVICE_LABEL = "quarkus-dev-service-openfga";
     static final String CONFIG_PREFIX = "quarkus.openfga.";
     static final String URL_CONFIG_KEY = CONFIG_PREFIX + "url";
-    static final String STORE_ID_CONFIG_KEY = CONFIG_PREFIX + "store-id";
+    static final String STORE_ID_CONFIG_KEY = CONFIG_PREFIX + "store";
     static final String AUTHORIZATION_MODEL_ID_CONFIG_KEY = CONFIG_PREFIX + "authorization-model-id";
     static final ContainerLocator openFGAContainerLocator = new ContainerLocator(DEV_SERVICE_LABEL, OPEN_FGA_EXPOSED_PORT);
     static final Duration INIT_OP_MAX_WAIT = Duration.ofSeconds(5);
@@ -269,7 +270,7 @@ public class DevServicesOpenFGAProcessor {
                         loadAuthorizationModelDefinition(api, devServicesConfig)
                                 .ifPresent(authModelDef -> {
                                     try {
-                                        var client = new AuthorizationModelsClient(api, storeId);
+                                        var client = new AuthorizationModelsClient(api, Uni.createFrom().item(storeId));
 
                                         var authModelId = client.listAll().await().atMost(INIT_OP_MAX_WAIT)
                                                 .stream()

--- a/deployment/src/test/java/io/quarkiverse/openfga/test/AuthorizationModelsClientTest.java
+++ b/deployment/src/test/java/io/quarkiverse/openfga/test/AuthorizationModelsClientTest.java
@@ -60,15 +60,17 @@ public class AuthorizationModelsClientTest {
 
         var typeDefinition = new TypeDefinition("document", Map.of("reader", Userset.direct()));
 
-        authorizationModelsClient.create(List.of(typeDefinition))
-                .subscribe().withSubscriber(UniAssertSubscriber.create())
-                .awaitItem();
+        for (int c = 0; c < 4; c++) {
+            authorizationModelsClient.create(List.of(typeDefinition))
+                    .subscribe().withSubscriber(UniAssertSubscriber.create())
+                    .awaitItem();
+        }
 
-        var models = authorizationModelsClient.listAll()
+        var models = authorizationModelsClient.listAll(1)
                 .subscribe().withSubscriber(UniAssertSubscriber.create())
                 .awaitItem()
                 .getItem();
 
-        assertThat(models, hasSize(1));
+        assertThat(models, hasSize(4));
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/openfga/client/AssertionsClient.java
+++ b/runtime/src/main/java/io/quarkiverse/openfga/client/AssertionsClient.java
@@ -11,22 +11,23 @@ import io.smallrye.mutiny.Uni;
 public class AssertionsClient {
 
     private final API api;
-    private final String storeId;
+    private final Uni<String> storeId;
     private final String authorizationModelId;
 
-    public AssertionsClient(API api, String storeId, String authorizationModelId) {
+    public AssertionsClient(API api, Uni<String> storeId, String authorizationModelId) {
         this.api = api;
         this.storeId = storeId;
         this.authorizationModelId = authorizationModelId;
     }
 
     public Uni<List<Assertion>> list() {
-        return api.readAssertions(storeId, authorizationModelId)
+        return storeId.flatMap(storeId -> api.readAssertions(storeId, authorizationModelId))
                 .map(ReadAssertionsResponse::getAssertions);
     }
 
     public Uni<Void> update(List<Assertion> assertions) {
-        return api.writeAssertions(storeId, authorizationModelId, new WriteAssertionsRequest(assertions));
+        return storeId
+                .flatMap(storeId -> api.writeAssertions(storeId, authorizationModelId, new WriteAssertionsRequest(assertions)));
     }
 
 }

--- a/runtime/src/main/java/io/quarkiverse/openfga/client/AuthorizationModelClient.java
+++ b/runtime/src/main/java/io/quarkiverse/openfga/client/AuthorizationModelClient.java
@@ -16,42 +16,44 @@ import io.smallrye.mutiny.Uni;
 public class AuthorizationModelClient {
 
     private final API api;
-    private final String storeId;
+    private final Uni<String> storeId;
     private final String authorizationModelId;
 
-    public AuthorizationModelClient(API api, String storeId, @Nullable String authorizationModelId) {
+    public AuthorizationModelClient(API api, Uni<String> storeId, @Nullable String authorizationModelId) {
         this.api = api;
         this.storeId = storeId;
         this.authorizationModelId = authorizationModelId;
     }
 
     public Uni<AuthorizationModel> get() {
-        return api.readAuthorizationModel(storeId, authorizationModelId)
+        return storeId.flatMap(storeId -> api.readAuthorizationModel(storeId, authorizationModelId))
                 .map(ReadAuthorizationModelResponse::getAuthorizationModel);
     }
 
     public Uni<Boolean> check(TupleKey tupleKey, @Nullable ContextualTupleKeys contextualTupleKeys) {
-        return api.check(storeId, new CheckBody(tupleKey, contextualTupleKeys, authorizationModelId, null))
+        return storeId
+                .flatMap(
+                        storeId -> api.check(storeId, new CheckBody(tupleKey, contextualTupleKeys, authorizationModelId, null)))
                 .map(CheckResponse::getAllowed);
     }
 
     public Uni<UsersetTree> expand(TupleKey tupleKey) {
-        return api.expand(storeId, new ExpandBody(tupleKey, authorizationModelId))
+        return storeId.flatMap(storeId -> api.expand(storeId, new ExpandBody(tupleKey, authorizationModelId)))
                 .map(ExpandResponse::getTree);
     }
 
     public Uni<List<String>> listObjects(String type, @Nullable String relation, String user,
             @Nullable List<TupleKey> contextualTupleKeys) {
-        return api
-                .listObjects(storeId,
-                        new ListObjectsBody(authorizationModelId, type, relation, user,
-                                contextualTupleKeys != null ? new ContextualTupleKeys(contextualTupleKeys) : null))
+        return storeId.flatMap(storeId -> api.listObjects(storeId,
+                new ListObjectsBody(authorizationModelId, type, relation, user,
+                        contextualTupleKeys != null ? new ContextualTupleKeys(contextualTupleKeys) : null)))
                 .map(ListObjectsResponse::getObjectIds);
     }
 
     public Uni<PaginatedList<Tuple>> queryTuples(PartialTupleKey tupleKey, @Nullable Integer pageSize,
             @Nullable String pagingToken) {
-        return api.read(storeId, new ReadBody(tupleKey, authorizationModelId, pageSize, pagingToken))
+        return storeId
+                .flatMap(storeId -> api.read(storeId, new ReadBody(tupleKey, authorizationModelId, pageSize, pagingToken)))
                 .map(res -> new PaginatedList<>(res.getTuples(), res.getContinuationToken()));
     }
 
@@ -66,7 +68,7 @@ public class AuthorizationModelClient {
     }
 
     public Uni<PaginatedList<Tuple>> readTuples(@Nullable Integer pageSize, @Nullable String pagingToken) {
-        return api.readTuples(storeId, new ReadTuplesBody(pageSize, pagingToken))
+        return storeId.flatMap(storeId -> api.readTuples(storeId, new ReadTuplesBody(pageSize, pagingToken)))
                 .map(res -> new PaginatedList<>(res.getTuples(), res.getContinuationToken()));
     }
 
@@ -84,7 +86,9 @@ public class AuthorizationModelClient {
     }
 
     public Uni<Map<String, Object>> write(@Nullable List<TupleKey> writes, @Nullable List<TupleKey> deletes) {
-        return api.write(storeId, new WriteBody(TupleKeys.of(writes), TupleKeys.of(deletes), authorizationModelId))
+        var writeKeys = TupleKeys.of(writes);
+        var deleteKeys = TupleKeys.of(deletes);
+        return storeId.flatMap(storeId -> api.write(storeId, new WriteBody(writeKeys, deleteKeys, authorizationModelId)))
                 .map(WriteResponse::getValues);
     }
 

--- a/runtime/src/main/java/io/quarkiverse/openfga/client/AuthorizationModelsClient.java
+++ b/runtime/src/main/java/io/quarkiverse/openfga/client/AuthorizationModelsClient.java
@@ -17,15 +17,15 @@ import io.smallrye.mutiny.Uni;
 public class AuthorizationModelsClient {
 
     private final API api;
-    private final String storeId;
+    private final Uni<String> storeId;
 
-    public AuthorizationModelsClient(API api, String storeId) {
+    public AuthorizationModelsClient(API api, Uni<String> storeId) {
         this.api = api;
         this.storeId = storeId;
     }
 
     public Uni<PaginatedList<AuthorizationModel>> list(@Nullable Integer pageSize, @Nullable String pagingToken) {
-        return api.readAuthorizationModels(storeId, pageSize, pagingToken)
+        return storeId.flatMap(storeId -> api.readAuthorizationModels(storeId, pageSize, pagingToken))
                 .map(res -> new PaginatedList<>(res.getAuthorizationModels(), res.getContinuationToken()));
     }
 
@@ -38,7 +38,7 @@ public class AuthorizationModelsClient {
     }
 
     public Uni<String> create(List<TypeDefinition> typeDefinitions) {
-        return api.writeAuthorizationModel(storeId, new TypeDefinitions(typeDefinitions))
+        return storeId.flatMap(storeId -> api.writeAuthorizationModel(storeId, new TypeDefinitions(typeDefinitions)))
                 .map(WriteAuthorizationModelResponse::getAuthorizationModelId);
     }
 

--- a/runtime/src/main/java/io/quarkiverse/openfga/client/OpenFGAClient.java
+++ b/runtime/src/main/java/io/quarkiverse/openfga/client/OpenFGAClient.java
@@ -1,8 +1,12 @@
 package io.quarkiverse.openfga.client;
 
 import static io.quarkiverse.openfga.client.utils.PaginatedList.collectAllPages;
+import static java.lang.String.format;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 import javax.enterprise.context.ApplicationScoped;
@@ -13,6 +17,7 @@ import io.quarkiverse.openfga.client.model.Store;
 import io.quarkiverse.openfga.client.model.dto.CreateStoreRequest;
 import io.quarkiverse.openfga.client.model.dto.CreateStoreResponse;
 import io.quarkiverse.openfga.client.utils.PaginatedList;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
 @ApplicationScoped
@@ -43,7 +48,66 @@ public class OpenFGAClient {
     }
 
     public StoreClient store(String storeId) {
-        return new StoreClient(api, storeId);
+        return new StoreClient(api, Uni.createFrom().item(storeId));
+    }
+
+    private static class StoreSearchResult {
+        Optional<String> storeId;
+        Optional<String> token;
+
+        StoreSearchResult(Optional<String> storeId, Optional<String> token) {
+            this.storeId = storeId;
+            this.token = token;
+        }
+
+        boolean isNotFinished() {
+            return storeId.isEmpty() && token.isPresent();
+        }
+    }
+
+    private static final Pattern STORE_ID_PATTERN = Pattern.compile("^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$");
+
+    public static Uni<String> storeIdResolver(API api, String storeIdOrName, boolean alwaysResolveStoreId) {
+        if (STORE_ID_PATTERN.matcher(storeIdOrName).matches() && !alwaysResolveStoreId) {
+            return Uni.createFrom().item(storeIdOrName);
+        }
+
+        return Multi.createBy()
+                .repeating().uni(AtomicReference<String>::new, lastToken -> {
+                    return api.listStores(null, lastToken.get())
+                            .onItem().invoke(list -> lastToken.set(list.getContinuationToken()))
+                            .map(response -> {
+
+                                var storeId = response.getStores().stream()
+                                        .filter(store -> store.getName().equals(storeIdOrName)
+                                                || store.getId().equals(storeIdOrName))
+                                        .map(Store::getId)
+                                        .findFirst();
+
+                                Optional<String> token;
+                                if (response.getContinuationToken() != null && !response.getContinuationToken().isEmpty()) {
+                                    token = Optional.of(response.getContinuationToken());
+                                } else {
+                                    token = Optional.empty();
+                                }
+
+                                return new StoreSearchResult(storeId, token);
+                            });
+                })
+                .whilst(StoreSearchResult::isNotFinished)
+                .select().last()
+                .flatMap(result -> {
+                    if (result.storeId.isEmpty() && result.token.isEmpty()) {
+                        return Multi.createFrom()
+                                .failure(new IllegalStateException(format("No store with name '%s'", storeIdOrName)));
+                    }
+                    if (result.storeId.isEmpty()) {
+                        return Multi.createFrom().nothing();
+                    }
+                    return Multi.createFrom().item(result.storeId.get());
+                })
+                .toUni()
+                .memoize().indefinitely();
     }
 
 }

--- a/runtime/src/main/java/io/quarkiverse/openfga/client/StoreClient.java
+++ b/runtime/src/main/java/io/quarkiverse/openfga/client/StoreClient.java
@@ -19,30 +19,30 @@ import io.smallrye.mutiny.Uni;
 public class StoreClient {
 
     private final API api;
-    private final String storeId;
+    private final Uni<String> storeId;
 
-    public StoreClient(API api, String storeId) {
+    public StoreClient(API api, Uni<String> storeId) {
         this.api = api;
         this.storeId = storeId;
-
     }
 
     public Uni<Store> get() {
-        return api.getStore(storeId).map(GetStoreResponse::asStore);
+        return storeId.flatMap(api::getStore)
+                .map(GetStoreResponse::asStore);
     }
 
     public Uni<Void> delete() {
-        return api.deleteStore(storeId);
+        return storeId.flatMap(api::deleteStore);
     }
 
     public Uni<List<TupleChange>> changes(@Nullable String type, @Nullable Integer pageSize,
             @Nullable String continuationToken) {
-        return api.readChanges(storeId, type, pageSize, continuationToken)
+        return storeId.flatMap(storeId -> api.readChanges(storeId, type, pageSize, continuationToken))
                 .map(ReadChangesResponse::getChanges);
     }
 
     public Uni<PaginatedList<Tuple>> readTuples(@Nullable Integer pageSize, @Nullable String pagingToken) {
-        return api.readTuples(storeId, new ReadTuplesBody(pageSize, pagingToken))
+        return storeId.flatMap(storeId -> api.readTuples(storeId, new ReadTuplesBody(pageSize, pagingToken)))
                 .map(res -> new PaginatedList<>(res.getTuples(), res.getContinuationToken()));
     }
 

--- a/runtime/src/main/java/io/quarkiverse/openfga/client/utils/PaginatedList.java
+++ b/runtime/src/main/java/io/quarkiverse/openfga/client/utils/PaginatedList.java
@@ -21,7 +21,7 @@ public final class PaginatedList<T> {
         this.token = token;
     }
 
-    public Boolean isLastPage() {
+    public Boolean isNotLastPage() {
         return token != null && !token.isEmpty();
     }
 
@@ -32,7 +32,7 @@ public final class PaginatedList<T> {
                     return listGenerator.apply(pageSize, lastToken.get())
                             .onItem().invoke(list -> lastToken.set(list.getToken()));
                 })
-                .whilst(PaginatedList::isLastPage)
+                .whilst(PaginatedList::isNotLastPage)
                 .onItem().transformToIterable(PaginatedList::getItems)
                 .collect().asList();
     }

--- a/runtime/src/main/java/io/quarkiverse/openfga/runtime/OpenFGARecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/openfga/runtime/OpenFGARecorder.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.openfga.runtime;
 
+import static io.quarkiverse.openfga.client.OpenFGAClient.storeIdResolver;
+
 import io.quarkiverse.openfga.client.AuthorizationModelClient;
 import io.quarkiverse.openfga.client.OpenFGAClient;
 import io.quarkiverse.openfga.client.StoreClient;
@@ -27,12 +29,14 @@ public class OpenFGARecorder {
     }
 
     public RuntimeValue<StoreClient> createStoreClient(RuntimeValue<API> api, OpenFGAConfig config) {
-        StoreClient storeClient = new StoreClient(api.getValue(), config.storeId);
+        var storeIdResolver = storeIdResolver(api.getValue(), config.store, config.alwaysResolveStoreId);
+        StoreClient storeClient = new StoreClient(api.getValue(), storeIdResolver);
         return new RuntimeValue<>(storeClient);
     }
 
     public RuntimeValue<AuthorizationModelClient> createAuthModelClient(RuntimeValue<API> api, OpenFGAConfig config) {
-        AuthorizationModelClient authModelClient = new AuthorizationModelClient(api.getValue(), config.storeId,
+        var storeIdResolver = storeIdResolver(api.getValue(), config.store, config.alwaysResolveStoreId);
+        AuthorizationModelClient authModelClient = new AuthorizationModelClient(api.getValue(), storeIdResolver,
                 config.authorizationModelId.orElse(null));
         return new RuntimeValue<>(authModelClient);
     }

--- a/runtime/src/main/java/io/quarkiverse/openfga/runtime/config/OpenFGAConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/openfga/runtime/config/OpenFGAConfig.java
@@ -38,10 +38,32 @@ public class OpenFGAConfig {
     public Optional<String> sharedKey;
 
     /**
-     * Store id for default {@link StoreClient} bean.
+     * Store id or name for default {@link StoreClient} bean.
+     * <p>
+     * If the provided property does not match the OpenFGA store id format
+     * ({@code ^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$}) it will be treated as
+     * a store name and a matching store id will be resolved at runtime.
+     * <p>
+     *
+     * @see #alwaysResolveStoreId
      */
     @ConfigItem
-    public String storeId;
+    public String store;
+
+    /**
+     * Always Treat {@link #store} as the name of a store and resolve the
+     * store id at runtime.
+     * <p>
+     * If true, the store id will always be resolved at runtime regardless
+     * of the format of the {@link #store} property. Otherwise, the store
+     * id will be resolved only when {@link #store} does not match the
+     * OpenFGA store id format.
+     * <p>
+     *
+     * @see #store
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean alwaysResolveStoreId;
 
     /**
      * Authorization model id for default {@link AuthorizationModelClient} bean.


### PR DESCRIPTION
When starting temporary instance of OpenFGA and automatically creating a store it’s difficult to know the generated store id.

Now store-ids are looked up when the `store` property is not of the correct format or when the `alwaysResolveStoreId` config property is true