### PR TITLE
Make equals methods compatible with Kotlin

### DIFF
--- a/model/src/main/java/io/quarkiverse/openfga/client/model/Assertion.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/Assertion.java
@@ -2,6 +2,8 @@ package io.quarkiverse.openfga.client.model;
 
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
@@ -25,7 +27,7 @@ public final class Assertion {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/AuthorizationModel.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/AuthorizationModel.java
@@ -3,6 +3,8 @@ package io.quarkiverse.openfga.client.model;
 import java.util.List;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
@@ -34,7 +36,7 @@ public final class AuthorizationModel {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/ContextualTupleKeys.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/ContextualTupleKeys.java
@@ -3,6 +3,8 @@ package io.quarkiverse.openfga.client.model;
 import java.util.List;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
@@ -21,7 +23,7 @@ public final class ContextualTupleKeys {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/ObjectRelation.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/ObjectRelation.java
@@ -2,6 +2,8 @@ package io.quarkiverse.openfga.client.model;
 
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
@@ -25,7 +27,7 @@ public final class ObjectRelation {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/PartialTupleKey.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/PartialTupleKey.java
@@ -41,7 +41,7 @@ public final class PartialTupleKey {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/Store.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/Store.java
@@ -55,7 +55,7 @@ public final class Store {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/Tuple.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/Tuple.java
@@ -3,6 +3,8 @@ package io.quarkiverse.openfga.client.model;
 import java.time.OffsetDateTime;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
 
 public final class Tuple {
@@ -23,7 +25,7 @@ public final class Tuple {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/TupleChange.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/TupleChange.java
@@ -3,6 +3,8 @@ package io.quarkiverse.openfga.client.model;
 import java.time.OffsetDateTime;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
@@ -32,7 +34,7 @@ public final class TupleChange {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/TupleKey.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/TupleKey.java
@@ -2,6 +2,8 @@ package io.quarkiverse.openfga.client.model;
 
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
 
 public final class TupleKey {
@@ -32,7 +34,7 @@ public final class TupleKey {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/TupleKeys.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/TupleKeys.java
@@ -33,7 +33,7 @@ public final class TupleKeys {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/TypeDefinition.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/TypeDefinition.java
@@ -39,7 +39,7 @@ public final class TypeDefinition {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/TypeDefinitions.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/TypeDefinitions.java
@@ -3,6 +3,8 @@ package io.quarkiverse.openfga.client.model;
 import java.util.List;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -23,7 +25,7 @@ public final class TypeDefinitions {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/Userset.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/Userset.java
@@ -122,7 +122,7 @@ public final class Userset {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/UsersetTree.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/UsersetTree.java
@@ -2,6 +2,8 @@ package io.quarkiverse.openfga.client.model;
 
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 import io.quarkiverse.openfga.client.model.nodes.Node;
@@ -20,7 +22,7 @@ public final class UsersetTree {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/Usersets.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/Usersets.java
@@ -3,6 +3,8 @@ package io.quarkiverse.openfga.client.model;
 import java.util.List;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
@@ -20,7 +22,7 @@ public final class Usersets {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/CheckBody.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/CheckBody.java
@@ -58,7 +58,7 @@ public final class CheckBody {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/CheckResponse.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/CheckResponse.java
@@ -29,7 +29,7 @@ public final class CheckResponse {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/CreateStoreRequest.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/CreateStoreRequest.java
@@ -4,6 +4,8 @@ import static com.fasterxml.jackson.annotation.JsonCreator.Mode.PROPERTIES;
 
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
@@ -21,7 +23,7 @@ public final class CreateStoreRequest {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/CreateStoreResponse.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/CreateStoreResponse.java
@@ -5,6 +5,8 @@ import static com.fasterxml.jackson.annotation.JsonCreator.Mode.PROPERTIES;
 import java.time.OffsetDateTime;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -51,7 +53,7 @@ public final class CreateStoreResponse {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ExpandBody.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ExpandBody.java
@@ -38,7 +38,7 @@ public final class ExpandBody {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ExpandResponse.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ExpandResponse.java
@@ -4,6 +4,8 @@ import static com.fasterxml.jackson.annotation.JsonCreator.Mode.PROPERTIES;
 
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 import io.quarkiverse.openfga.client.model.UsersetTree;
@@ -22,7 +24,7 @@ public final class ExpandResponse {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/GetStoreResponse.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/GetStoreResponse.java
@@ -5,6 +5,8 @@ import static com.fasterxml.jackson.annotation.JsonCreator.Mode.PROPERTIES;
 import java.time.OffsetDateTime;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -51,7 +53,7 @@ public final class GetStoreResponse {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ListObjectsBody.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ListObjectsBody.java
@@ -64,7 +64,7 @@ public final class ListObjectsBody {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ListObjectsResponse.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ListObjectsResponse.java
@@ -5,6 +5,8 @@ import static com.fasterxml.jackson.annotation.JsonCreator.Mode.PROPERTIES;
 import java.util.List;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -25,7 +27,7 @@ public final class ListObjectsResponse {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ListStoresResponse.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ListStoresResponse.java
@@ -36,7 +36,7 @@ public final class ListStoresResponse {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadAssertionsResponse.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadAssertionsResponse.java
@@ -5,6 +5,8 @@ import static com.fasterxml.jackson.annotation.JsonCreator.Mode.PROPERTIES;
 import java.util.List;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -33,7 +35,7 @@ public final class ReadAssertionsResponse {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadAuthorizationModelResponse.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadAuthorizationModelResponse.java
@@ -4,6 +4,8 @@ import static com.fasterxml.jackson.annotation.JsonCreator.Mode.PROPERTIES;
 
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -25,7 +27,7 @@ public final class ReadAuthorizationModelResponse {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadAuthorizationModelsResponse.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadAuthorizationModelsResponse.java
@@ -39,7 +39,7 @@ public final class ReadAuthorizationModelsResponse {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadBody.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadBody.java
@@ -60,7 +60,7 @@ public final class ReadBody {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadChangesResponse.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadChangesResponse.java
@@ -5,6 +5,8 @@ import static com.fasterxml.jackson.annotation.JsonCreator.Mode.PROPERTIES;
 import java.util.List;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 import io.quarkiverse.openfga.client.model.TupleChange;
@@ -23,7 +25,7 @@ public final class ReadChangesResponse {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadResponse.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadResponse.java
@@ -36,7 +36,7 @@ public final class ReadResponse {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadTuplesBody.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadTuplesBody.java
@@ -38,7 +38,7 @@ public final class ReadTuplesBody {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadTuplesResponse.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadTuplesResponse.java
@@ -36,7 +36,7 @@ public final class ReadTuplesResponse {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/WriteAssertionsRequest.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/WriteAssertionsRequest.java
@@ -5,6 +5,8 @@ import static com.fasterxml.jackson.annotation.JsonCreator.Mode.PROPERTIES;
 import java.util.List;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 import io.quarkiverse.openfga.client.model.Assertion;
@@ -23,7 +25,7 @@ public final class WriteAssertionsRequest {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/WriteAuthorizationModelResponse.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/WriteAuthorizationModelResponse.java
@@ -4,6 +4,8 @@ import static com.fasterxml.jackson.annotation.JsonCreator.Mode.PROPERTIES;
 
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -24,7 +26,7 @@ public final class WriteAuthorizationModelResponse {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/WriteBody.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/WriteBody.java
@@ -45,7 +45,7 @@ public final class WriteBody {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/nodes/Computed.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/nodes/Computed.java
@@ -2,6 +2,8 @@ package io.quarkiverse.openfga.client.model.nodes;
 
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
 
 public final class Computed {
@@ -16,7 +18,7 @@ public final class Computed {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/nodes/Difference.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/nodes/Difference.java
@@ -2,6 +2,8 @@ package io.quarkiverse.openfga.client.model.nodes;
 
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
 
 public final class Difference {
@@ -22,7 +24,7 @@ public final class Difference {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/nodes/Leaf.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/nodes/Leaf.java
@@ -37,7 +37,7 @@ public final class Leaf {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/nodes/Node.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/nodes/Node.java
@@ -51,7 +51,7 @@ public final class Node {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/nodes/Nodes.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/nodes/Nodes.java
@@ -3,6 +3,8 @@ package io.quarkiverse.openfga.client.model.nodes;
 import java.util.List;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
 
 public final class Nodes {
@@ -17,7 +19,7 @@ public final class Nodes {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/nodes/TupleToUserset.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/nodes/TupleToUserset.java
@@ -3,6 +3,8 @@ package io.quarkiverse.openfga.client.model.nodes;
 import java.util.List;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
 
 public final class TupleToUserset {
@@ -23,7 +25,7 @@ public final class TupleToUserset {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/nodes/Users.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/nodes/Users.java
@@ -3,6 +3,8 @@ package io.quarkiverse.openfga.client.model.nodes;
 import java.util.List;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
 
 public final class Users {
@@ -17,7 +19,7 @@ public final class Users {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/nodes/V1.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/nodes/V1.java
@@ -2,6 +2,8 @@ package io.quarkiverse.openfga.client.model.nodes;
 
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import io.quarkiverse.openfga.client.model.ObjectRelation;
 import io.quarkiverse.openfga.client.model.Userset;
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
@@ -26,7 +28,7 @@ public class V1 {
         }
 
         @Override
-        public boolean equals(Object obj) {
+        public boolean equals(@Nullable Object obj) {
             if (obj == this)
                 return true;
             if (obj == null || obj.getClass() != this.getClass())
@@ -68,7 +70,7 @@ public class V1 {
         }
 
         @Override
-        public boolean equals(Object obj) {
+        public boolean equals(@Nullable Object obj) {
             if (obj == this)
                 return true;
             if (obj == null || obj.getClass() != this.getClass())

--- a/runtime/src/main/java/io/quarkiverse/openfga/client/utils/PaginatedList.java
+++ b/runtime/src/main/java/io/quarkiverse/openfga/client/utils/PaginatedList.java
@@ -47,7 +47,7 @@ public final class PaginatedList<T> {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())


### PR DESCRIPTION
Kotlin doesn’t allow equals to be annotated with @Nonnull or equivalent.