### PR TITLE
Remove use of global TLSConfig

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/openfga/deployment/OpenFGAProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/openfga/deployment/OpenFGAProcessor.java
@@ -21,7 +21,6 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.*;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.runtime.RuntimeValue;
-import io.quarkus.runtime.TlsConfig;
 import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 import io.quarkus.vertx.deployment.VertxBuildItem;
 
@@ -52,8 +51,6 @@ class OpenFGAProcessor {
     ServiceStartBuildItem registerSyntheticBeans(
             OpenFGABuildTimeConfig buildTimeConfig,
             OpenFGAConfig runtimeConfig,
-            TlsConfig tlsConfig,
-            SslNativeConfigBuildItem sslNativeConfig,
             VertxBuildItem vertx,
             ShutdownContextBuildItem shutdownContextBuildItem,
             OpenFGARecorder recorder,
@@ -62,7 +59,7 @@ class OpenFGAProcessor {
             BuildProducer<ExtensionSslNativeSupportBuildItem> sslNativeSupport) {
 
         RuntimeValue<API> apiValue = recorder.createAPI(
-                runtimeConfig, tlsConfig, buildTimeConfig.tracingEnabled,
+                runtimeConfig, buildTimeConfig.tracingEnabled,
                 vertx.getVertx(), shutdownContextBuildItem);
 
         sslNativeSupport.produce(new ExtensionSslNativeSupportBuildItem(FEATURE));

--- a/runtime/src/main/java/io/quarkiverse/openfga/client/api/API.java
+++ b/runtime/src/main/java/io/quarkiverse/openfga/client/api/API.java
@@ -28,7 +28,6 @@ import io.quarkiverse.openfga.client.model.TupleKey;
 import io.quarkiverse.openfga.client.model.TypeDefinitions;
 import io.quarkiverse.openfga.client.model.dto.*;
 import io.quarkiverse.openfga.runtime.config.OpenFGAConfig;
-import io.quarkus.runtime.TlsConfig;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
@@ -49,8 +48,8 @@ public class API implements Closeable {
     private final Optional<Credentials> credentials;
     private final ObjectMapper objectMapper;
 
-    public API(OpenFGAConfig config, TlsConfig tlsConfig, boolean tracingEnabled, Vertx vertx) {
-        this(VertxWebClientFactory.create(config, tlsConfig, tracingEnabled, vertx),
+    public API(OpenFGAConfig config, boolean globalTrustAll, boolean tracingEnabled, Vertx vertx) {
+        this(VertxWebClientFactory.create(config, globalTrustAll, tracingEnabled, vertx),
                 config.sharedKey.map(TokenCredentials::new));
     }
 

--- a/runtime/src/main/java/io/quarkiverse/openfga/client/api/VertxWebClientFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/openfga/client/api/VertxWebClientFactory.java
@@ -7,7 +7,6 @@ import java.net.URL;
 import org.jboss.logging.Logger;
 
 import io.quarkiverse.openfga.runtime.config.OpenFGAConfig;
-import io.quarkus.runtime.TlsConfig;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.ext.web.client.WebClientOptions;
@@ -18,7 +17,7 @@ public class VertxWebClientFactory {
 
     private static final Logger log = Logger.getLogger(VertxWebClientFactory.class.getName());
 
-    public static WebClient create(OpenFGAConfig config, TlsConfig tlsConfig, boolean tracingEnabled, Vertx vertx) {
+    public static WebClient create(OpenFGAConfig config, boolean globalTrustAll, boolean tracingEnabled, Vertx vertx) {
 
         var url = config.url;
 
@@ -32,7 +31,7 @@ public class VertxWebClientFactory {
 
         config.nonProxyHosts.ifPresent(options::setNonProxyHosts);
 
-        boolean trustAll = config.tls.skipVerify.orElseGet(() -> tlsConfig.trustAll);
+        boolean trustAll = config.tls.skipVerify.orElseGet(() -> globalTrustAll);
         if (trustAll) {
             skipVerify(options);
         } else {


### PR DESCRIPTION
It has been replaced with the TLS registry. This allows the plugin to cotinue working as before, until it is converted to use the TLS registry as well.