### PR TITLE
Rework clients to common endpoint options and fix parameter passing

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/openfga/test/AuthorizationModelClientTest.java
+++ b/deployment/src/test/java/io/quarkiverse/openfga/test/AuthorizationModelClientTest.java
@@ -270,7 +270,7 @@ public class AuthorizationModelClientTest {
                 .subscribe().withSubscriber(UniAssertSubscriber.create())
                 .awaitItem();
 
-        var objects = authorizationModelClient.listObjects("document", "writer", "user:me", null)
+        var objects = authorizationModelClient.listObjects("document", "writer", "user:me")
                 .subscribe().withSubscriber(UniAssertSubscriber.create())
                 .awaitItem()
                 .getItem();

--- a/deployment/src/test/java/io/quarkiverse/openfga/test/DefaultAuthorizationModelClientTest.java
+++ b/deployment/src/test/java/io/quarkiverse/openfga/test/DefaultAuthorizationModelClientTest.java
@@ -258,7 +258,7 @@ public class DefaultAuthorizationModelClientTest {
                 .subscribe().withSubscriber(UniAssertSubscriber.create())
                 .awaitItem();
 
-        var tuples = authorizationModelClient.listObjects("document", "writer", "user:me", null)
+        var tuples = authorizationModelClient.listObjects("document", "writer", "user:me")
                 .subscribe().withSubscriber(UniAssertSubscriber.create())
                 .awaitItem()
                 .getItem();

--- a/deployment/src/test/java/io/quarkiverse/openfga/test/StoreClientTest.java
+++ b/deployment/src/test/java/io/quarkiverse/openfga/test/StoreClientTest.java
@@ -2,7 +2,11 @@ package io.quarkiverse.openfga.test;
 
 import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import java.time.OffsetDateTime;
+import java.util.List;
 
 import jakarta.inject.Inject;
 
@@ -14,9 +18,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkiverse.openfga.client.AuthorizationModelClient;
 import io.quarkiverse.openfga.client.OpenFGAClient;
 import io.quarkiverse.openfga.client.StoreClient;
-import io.quarkiverse.openfga.client.model.Store;
+import io.quarkiverse.openfga.client.StoreClient.ReadChangesFilter;
+import io.quarkiverse.openfga.client.model.*;
+import io.quarkiverse.openfga.client.utils.Pagination;
 import io.quarkus.test.QuarkusUnitTest;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 
@@ -25,7 +32,8 @@ public class StoreClientTest {
     // Start unit test with extension loaded
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("auth-model.json"));
 
     @Inject
     OpenFGAClient openFGAClient;
@@ -44,6 +52,25 @@ public class StoreClientTest {
     public void deleteTestStore() {
         if (storeClient != null) {
             storeClient.delete().await().atMost(ofSeconds(10));
+        }
+    }
+
+    private AuthorizationModelClient initializeAuthorizationModel() throws Exception {
+
+        try (var schemaStream = unitTest.getArchiveProducer().get().get("/auth-model.json").getAsset().openStream()) {
+            if (schemaStream == null) {
+                throw new IllegalStateException("Could not find auth-model.json");
+            }
+
+            var schema = AuthorizationModelSchema.parse(schemaStream);
+
+            var authorizationModelId = storeClient.authorizationModels()
+                    .create(schema)
+                    .subscribe().withSubscriber(UniAssertSubscriber.create())
+                    .awaitItem()
+                    .getItem();
+
+            return storeClient.authorizationModels().model(authorizationModelId);
         }
     }
 
@@ -84,4 +111,182 @@ public class StoreClientTest {
                 .doesNotContain(store);
     }
 
+    @Test
+    @DisplayName("Can Read Changes")
+    public void canReadChanges() throws Exception {
+        var authorizationModelClient = initializeAuthorizationModel();
+        authorizationModelClient.write(
+                List.of(
+                        ConditionalTupleKey.of("thing:1", "owner", "user:me"),
+                        ConditionalTupleKey.of("thing:2", "owner", "user:you"),
+                        ConditionalTupleKey.of("thing:3", "reader", "user:me")),
+                List.of()).subscribe()
+                .withSubscriber(UniAssertSubscriber.create())
+                .awaitItem();
+
+        authorizationModelClient.write(
+                List.of(),
+                List.of(TupleKey.of("thing:3", "reader", "user:me"))).subscribe()
+                .withSubscriber(UniAssertSubscriber.create())
+                .awaitItem();
+
+        var changes = storeClient.readChanges()
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
+                .awaitItem()
+                .getItem();
+        assertThat(changes.getItems())
+                .hasSize(4)
+                .extracting("tupleKey", "operation")
+                .containsExactlyInAnyOrder(
+                        tuple(ConditionalTupleKey.of("thing:1", "owner", "user:me"), TupleOperation.WRITE),
+                        tuple(ConditionalTupleKey.of("thing:2", "owner", "user:you"), TupleOperation.WRITE),
+                        tuple(ConditionalTupleKey.of("thing:3", "reader", "user:me"), TupleOperation.WRITE),
+                        tuple(ConditionalTupleKey.of("thing:3", "reader", "user:me"), TupleOperation.DELETE));
+    }
+
+    @Test
+    @DisplayName("Can Read Changes With Pagination")
+    public void canReadChangesWithPagination() throws Exception {
+        var authorizationModelClient = initializeAuthorizationModel();
+        authorizationModelClient.write(
+                List.of(
+                        ConditionalTupleKey.of("thing:1", "owner", "user:me"),
+                        ConditionalTupleKey.of("thing:1", "reader", "user:you"),
+                        ConditionalTupleKey.of("thing:2", "owner", "user:you"),
+                        ConditionalTupleKey.of("thing:2", "reader", "user:me"),
+                        ConditionalTupleKey.of("thing:3", "owner", "user:me"),
+                        ConditionalTupleKey.of("thing:3", "reader", "user:you")),
+                List.of()).subscribe()
+                .withSubscriber(UniAssertSubscriber.create())
+                .awaitItem();
+
+        var page1 = storeClient.readChanges(Pagination.limitedTo(2))
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
+                .awaitItem()
+                .getItem();
+        assertThat(page1.getItems())
+                .hasSize(2)
+                .extracting("tupleKey.object", "tupleKey.relation", "tupleKey.user")
+                .containsExactly(
+                        tuple("thing:1", "owner", "user:me"),
+                        tuple("thing:1", "reader", "user:you"));
+        assertThat(page1.getToken()).isNotNull();
+
+        var page2 = storeClient.readChanges(Pagination.limitedTo(2).andContinuingFrom(page1.getToken()))
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
+                .awaitItem()
+                .getItem();
+        assertThat(page2.getItems())
+                .hasSize(2)
+                .extracting("tupleKey.object", "tupleKey.relation", "tupleKey.user")
+                .containsExactly(
+                        tuple("thing:2", "owner", "user:you"),
+                        tuple("thing:2", "reader", "user:me"));
+        assertThat(page2.getToken()).isNotNull();
+
+        var page3 = storeClient.readChanges(Pagination.limitedTo(2).andContinuingFrom(page2.getToken()))
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
+                .awaitItem()
+                .getItem();
+        assertThat(page3.getItems())
+                .hasSize(2)
+                .extracting("tupleKey.object", "tupleKey.relation", "tupleKey.user")
+                .containsExactly(
+                        tuple("thing:3", "owner", "user:me"),
+                        tuple("thing:3", "reader", "user:you"));
+        assertThat(page3.getToken()).isNotNull();
+
+        var page4 = storeClient.readChanges(Pagination.limitedTo(2).andContinuingFrom(page3.getToken()))
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
+                .awaitItem()
+                .getItem();
+        assertThat(page4.getItems()).isEmpty();
+        assertThat(page4.getToken()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Can Read Changes with Filter")
+    public void canReadChangesWithFilter() throws Exception {
+        var authorizationModelClient = initializeAuthorizationModel();
+        authorizationModelClient.write(
+                List.of(
+                        ConditionalTupleKey.of("thing:1", "owner", "user:me"),
+                        ConditionalTupleKey.of("thing:2", "owner", "user:you"),
+                        ConditionalTupleKey.of("thing:3", "reader", "user:me"),
+                        ConditionalTupleKey.of("other-thing:1", "owner", "user:me"),
+                        ConditionalTupleKey.of("other-thing:2", "reader", "group:us")),
+                List.of()).subscribe()
+                .withSubscriber(UniAssertSubscriber.create())
+                .awaitItem();
+
+        authorizationModelClient.write(
+                List.of(),
+                List.of(TupleKey.of("thing:3", "reader", "user:me"))).subscribe()
+                .withSubscriber(UniAssertSubscriber.create())
+                .awaitItem();
+
+        var thingChanges = storeClient.readChanges(ReadChangesFilter.only("thing"))
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
+                .awaitItem()
+                .getItem();
+        assertThat(thingChanges.getItems())
+                .hasSize(4)
+                .extracting("tupleKey.object", "operation")
+                .containsExactly(
+                        tuple("thing:1", TupleOperation.WRITE),
+                        tuple("thing:2", TupleOperation.WRITE),
+                        tuple("thing:3", TupleOperation.WRITE),
+                        tuple("thing:3", TupleOperation.DELETE));
+
+        var otherThingChanges = storeClient.readChanges(ReadChangesFilter.only("other-thing"))
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
+                .awaitItem()
+                .getItem();
+        assertThat(otherThingChanges.getItems())
+                .hasSize(2)
+                .extracting("tupleKey.object", "operation")
+                .containsExactly(
+                        tuple("other-thing:1", TupleOperation.WRITE),
+                        tuple("other-thing:2", TupleOperation.WRITE));
+    }
+
+    @Test
+    @DisplayName("Can Read Changes After Start Time")
+    public void canReadChangesAfterStart() throws Exception {
+        var authorizationModelClient = initializeAuthorizationModel();
+        authorizationModelClient.write(
+                List.of(
+                        ConditionalTupleKey.of("thing:1", "owner", "user:me"),
+                        ConditionalTupleKey.of("thing:1", "reader", "user:you"),
+                        ConditionalTupleKey.of("thing:2", "owner", "user:you")),
+                List.of()).subscribe()
+                .withSubscriber(UniAssertSubscriber.create())
+                .awaitItem();
+
+        Thread.sleep(1000);
+
+        var time = OffsetDateTime.now();
+
+        authorizationModelClient.write(
+                List.of(
+                        ConditionalTupleKey.of("thing:2", "reader", "user:me"),
+                        ConditionalTupleKey.of("thing:3", "owner", "user:me"),
+                        ConditionalTupleKey.of("thing:3", "reader", "user:you")),
+                List.of(TupleKey.of("thing:1", "reader", "user:you"))).subscribe()
+                .withSubscriber(UniAssertSubscriber.create())
+                .awaitItem();
+
+        var thingChanges = storeClient.readChanges(ReadChangesFilter.since(time))
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
+                .awaitItem()
+                .getItem();
+        assertThat(thingChanges.getItems())
+                .hasSize(4)
+                .extracting("tupleKey.object", "operation")
+                .containsExactly(
+                        tuple("thing:1", TupleOperation.DELETE),
+                        tuple("thing:2", TupleOperation.WRITE),
+                        tuple("thing:3", TupleOperation.WRITE),
+                        tuple("thing:3", TupleOperation.WRITE));
+    }
 }

--- a/deployment/src/test/resources/auth-model.json
+++ b/deployment/src/test/resources/auth-model.json
@@ -5,6 +5,9 @@
       "type": "user"
     },
     {
+      "type": "group"
+    },
+    {
       "type": "thing",
       "relations": {
         "reader": {
@@ -23,6 +26,9 @@
             "directly_related_user_types": [
               {
                 "type": "user"
+              },
+              {
+                "type": "group"
               }
             ]
           },
@@ -30,6 +36,9 @@
             "directly_related_user_types": [
               {
                 "type": "user"
+              },
+              {
+                "type": "group"
               }
             ]
           },
@@ -37,6 +46,57 @@
             "directly_related_user_types": [
               {
                 "type": "user"
+              },
+              {
+                "type": "group"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "other-thing",
+      "relations": {
+        "reader": {
+          "this": {}
+        },
+        "writer": {
+          "this": {}
+        },
+        "owner": {
+          "this": {}
+        }
+      },
+      "metadata": {
+        "relations": {
+          "reader": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "group"
+              }
+            ]
+          },
+          "writer": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "group"
+              }
+            ]
+          },
+          "owner": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "group"
               }
             ]
           }

--- a/integration-tests/src/main/java/io/quarkiverse/openfga/it/OpenFGAResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/openfga/it/OpenFGAResource.java
@@ -28,6 +28,7 @@ import jakarta.ws.rs.Produces;
 
 import io.quarkiverse.openfga.client.*;
 import io.quarkiverse.openfga.client.model.*;
+import io.quarkiverse.openfga.client.utils.PaginatedList;
 import io.smallrye.mutiny.Uni;
 
 @Path("/openfga")
@@ -59,8 +60,8 @@ public class OpenFGAResource {
     @GET
     @Path("changes")
     @Produces(APPLICATION_JSON)
-    public Uni<List<TupleChange>> listChanges() {
-        return storeClient.listChanges(null, null, null);
+    public Uni<List<TupleChange>> readChanges() {
+        return storeClient.readChanges().map(PaginatedList::getItems);
     }
 
     @GET

--- a/integration-tests/src/test/java/io/quarkiverse/openfga/it/OpenFGAResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/openfga/it/OpenFGAResourceTest.java
@@ -23,7 +23,7 @@ public class OpenFGAResourceTest {
     }
 
     @Test
-    public void testListChanges() {
+    public void testReadChanges() {
 
         given()
                 .when().get("/openfga/changes")

--- a/integration-tests/src/test/resources/auth-model.json
+++ b/integration-tests/src/test/resources/auth-model.json
@@ -5,6 +5,9 @@
       "type": "user"
     },
     {
+      "type": "group"
+    },
+    {
       "type": "thing",
       "relations": {
         "reader": {
@@ -23,6 +26,9 @@
             "directly_related_user_types": [
               {
                 "type": "user"
+              },
+              {
+                "type": "group"
               }
             ]
           },
@@ -30,6 +36,9 @@
             "directly_related_user_types": [
               {
                 "type": "user"
+              },
+              {
+                "type": "group"
               }
             ]
           },
@@ -37,6 +46,57 @@
             "directly_related_user_types": [
               {
                 "type": "user"
+              },
+              {
+                "type": "group"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "other-thing",
+      "relations": {
+        "reader": {
+          "this": {}
+        },
+        "writer": {
+          "this": {}
+        },
+        "owner": {
+          "this": {}
+        }
+      },
+      "metadata": {
+        "relations": {
+          "reader": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "group"
+              }
+            ]
+          },
+          "writer": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "group"
+              }
+            ]
+          },
+          "owner": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "group"
               }
             ]
           }

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/Assertion.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/Assertion.java
@@ -27,7 +27,7 @@ public final class Assertion {
         this.contextualTuples = contextualTuples;
     }
 
-    public Assertion of(TupleKey tupleKey, boolean expectation, @Nullable List<TupleKey> contextualTuples) {
+    public static Assertion of(TupleKey tupleKey, boolean expectation, @Nullable List<TupleKey> contextualTuples) {
         return new Assertion(tupleKey, expectation, contextualTuples);
     }
 

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/AuthorizationModelSchema.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/AuthorizationModelSchema.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.openfga.client.model;
 
+import java.io.*;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -9,6 +10,7 @@ import javax.annotation.Nullable;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import io.quarkiverse.openfga.client.model.utils.ModelMapper;
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
 
 public final class AuthorizationModelSchema {
@@ -39,6 +41,22 @@ public final class AuthorizationModelSchema {
     public static AuthorizationModelSchema of(@JsonProperty("type_definitions") List<TypeDefinition> typeDefinitions,
             @Nullable Map<String, Condition> conditions) {
         return of(Defaults.SCHEMA_VERSION, typeDefinitions, conditions);
+    }
+
+    public static AuthorizationModelSchema parse(InputStream stream) throws IOException {
+        return ModelMapper.mapper.readValue(stream, AuthorizationModelSchema.class);
+    }
+
+    public static AuthorizationModelSchema parse(Reader reader) throws IOException {
+        return ModelMapper.mapper.readValue(reader, AuthorizationModelSchema.class);
+    }
+
+    public static AuthorizationModelSchema parse(byte[] bytes) throws IOException {
+        return ModelMapper.mapper.readValue(bytes, AuthorizationModelSchema.class);
+    }
+
+    public static AuthorizationModelSchema parse(String json) throws IOException {
+        return ModelMapper.mapper.readValue(json, AuthorizationModelSchema.class);
     }
 
     @JsonProperty("schema_version")

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/ContextualTupleKeys.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/ContextualTupleKeys.java
@@ -1,5 +1,8 @@
 package io.quarkiverse.openfga.client.model;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
 import java.util.List;
 import java.util.Objects;
 
@@ -7,7 +10,9 @@ import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 
+import io.quarkiverse.openfga.client.model.utils.ModelMapper;
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
 
 public final class ContextualTupleKeys {
@@ -27,6 +32,46 @@ public final class ContextualTupleKeys {
         if (tupleKeys == null) {
             return null;
         }
+        return new ContextualTupleKeys(tupleKeys);
+    }
+
+    public static ContextualTupleKeys parse(InputStream stream) throws IOException {
+        return ModelMapper.mapper.readValue(stream, ContextualTupleKeys.class);
+    }
+
+    public static ContextualTupleKeys parse(Reader reader) throws IOException {
+        return ModelMapper.mapper.readValue(reader, ContextualTupleKeys.class);
+    }
+
+    public static ContextualTupleKeys parse(String json) throws IOException {
+        return ModelMapper.mapper.readValue(json, ContextualTupleKeys.class);
+    }
+
+    public static ContextualTupleKeys parse(byte[] bytes) throws IOException {
+        return ModelMapper.mapper.readValue(bytes, ContextualTupleKeys.class);
+    }
+
+    public static ContextualTupleKeys parseList(InputStream stream) throws IOException {
+        List<ConditionalTupleKey> tupleKeys = ModelMapper.mapper.readValue(stream, new TypeReference<>() {
+        });
+        return new ContextualTupleKeys(tupleKeys);
+    }
+
+    public static ContextualTupleKeys parseList(Reader reader) throws IOException {
+        List<ConditionalTupleKey> tupleKeys = ModelMapper.mapper.readValue(reader, new TypeReference<>() {
+        });
+        return new ContextualTupleKeys(tupleKeys);
+    }
+
+    public static ContextualTupleKeys parseList(String json) throws IOException {
+        List<ConditionalTupleKey> tupleKeys = ModelMapper.mapper.readValue(json, new TypeReference<>() {
+        });
+        return new ContextualTupleKeys(tupleKeys);
+    }
+
+    public static ContextualTupleKeys parseList(byte[] bytes) throws IOException {
+        List<ConditionalTupleKey> tupleKeys = ModelMapper.mapper.readValue(bytes, new TypeReference<>() {
+        });
         return new ContextualTupleKeys(tupleKeys);
     }
 

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ListStoresRequest.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ListStoresRequest.java
@@ -17,20 +17,27 @@ public final class ListStoresRequest {
     @Nullable
     private final String continuationToken;
 
+    @JsonProperty("name")
+    @Nullable
+    private final String name;
+
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     ListStoresRequest(@JsonProperty("page_size") @Nullable Integer pageSize,
-            @JsonProperty("continuation_token") @Nullable String continuationToken) {
+            @JsonProperty("continuation_token") @Nullable String continuationToken,
+            @JsonProperty("name") @Nullable String name) {
         this.pageSize = pageSize;
         this.continuationToken = continuationToken;
+        this.name = name;
     }
 
-    public static ListStoresRequest of(@Nullable Integer pageSize, @Nullable String continuationToken) {
-        return new ListStoresRequest(pageSize, continuationToken);
+    public static ListStoresRequest of(@Nullable Integer pageSize, @Nullable String continuationToken, @Nullable String name) {
+        return new ListStoresRequest(pageSize, continuationToken, name);
     }
 
     public static final class Builder {
         private Integer pageSize;
         private String continuationToken;
+        private String name;
 
         Builder() {
         }
@@ -45,8 +52,13 @@ public final class ListStoresRequest {
             return this;
         }
 
+        public Builder name(@Nullable String name) {
+            this.name = name;
+            return this;
+        }
+
         public ListStoresRequest build() {
-            return new ListStoresRequest(pageSize, continuationToken);
+            return new ListStoresRequest(pageSize, continuationToken, name);
         }
     }
 
@@ -66,6 +78,12 @@ public final class ListStoresRequest {
         return continuationToken;
     }
 
+    @JsonProperty("name")
+    @Nullable
+    public String getName() {
+        return name;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this)
@@ -74,19 +92,21 @@ public final class ListStoresRequest {
             return false;
         var that = (ListStoresRequest) obj;
         return Objects.equals(this.pageSize, that.pageSize) &&
-                Objects.equals(this.continuationToken, that.continuationToken);
+                Objects.equals(this.continuationToken, that.continuationToken) &&
+                Objects.equals(this.name, that.name);
     }
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(pageSize, continuationToken);
+        return java.util.Objects.hash(pageSize, continuationToken, name);
     }
 
     @Override
     public String toString() {
         return "ListStoresRequest[" +
                 "pageSize=" + pageSize + ", " +
-                "continuationToken=" + continuationToken + ']';
+                "continuationToken=" + continuationToken + ", "
+                + "name=" + name + ']';
     }
 
 }

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadChangesRequest.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadChangesRequest.java
@@ -2,6 +2,7 @@ package io.quarkiverse.openfga.client.model.dto;
 
 import static com.fasterxml.jackson.annotation.JsonCreator.Mode.PROPERTIES;
 
+import java.time.OffsetDateTime;
 import java.util.Objects;
 
 import javax.annotation.Nullable;
@@ -9,7 +10,7 @@ import javax.annotation.Nullable;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public final class ListChangesRequest {
+public final class ReadChangesRequest {
 
     @Nullable
     private final String type;
@@ -22,22 +23,30 @@ public final class ListChangesRequest {
     @Nullable
     private final String continuationToken;
 
+    @JsonProperty("start_time")
+    @Nullable
+    private final OffsetDateTime startTime;
+
     @JsonCreator(mode = PROPERTIES)
-    ListChangesRequest(@Nullable String type, @JsonProperty("page_size") @Nullable Integer pageSize,
-            @JsonProperty("continuation_token") @Nullable String continuationToken) {
+    ReadChangesRequest(@Nullable String type, @JsonProperty("page_size") @Nullable Integer pageSize,
+            @JsonProperty("continuation_token") @Nullable String continuationToken,
+            @JsonProperty("start_time") @Nullable OffsetDateTime startTime) {
         this.type = type;
         this.pageSize = pageSize;
         this.continuationToken = continuationToken;
+        this.startTime = startTime;
     }
 
-    public static ListChangesRequest of(@Nullable String type, @Nullable Integer pageSize, @Nullable String continuationToken) {
-        return new ListChangesRequest(type, pageSize, continuationToken);
+    public static ReadChangesRequest of(@Nullable String type, @Nullable Integer pageSize, @Nullable String continuationToken,
+            @Nullable OffsetDateTime startTime) {
+        return new ReadChangesRequest(type, pageSize, continuationToken, startTime);
     }
 
     public static final class Builder {
         private String type;
         private Integer pageSize;
         private String continuationToken;
+        private OffsetDateTime startTime;
 
         public Builder() {
         }
@@ -57,8 +66,13 @@ public final class ListChangesRequest {
             return this;
         }
 
-        public ListChangesRequest build() {
-            return new ListChangesRequest(type, pageSize, continuationToken);
+        public Builder startTime(@Nullable OffsetDateTime startTime) {
+            this.startTime = startTime;
+            return this;
+        }
+
+        public ReadChangesRequest build() {
+            return new ReadChangesRequest(type, pageSize, continuationToken, startTime);
         }
     }
 
@@ -83,29 +97,37 @@ public final class ListChangesRequest {
         return continuationToken;
     }
 
+    @JsonProperty("start_time")
+    @Nullable
+    public OffsetDateTime getStartTime() {
+        return startTime;
+    }
+
     @Override
     public boolean equals(@Nullable Object obj) {
         if (obj == this)
             return true;
         if (obj == null || obj.getClass() != this.getClass())
             return false;
-        var that = (ListChangesRequest) obj;
+        var that = (ReadChangesRequest) obj;
         return Objects.equals(this.type, that.type) &&
                 Objects.equals(this.pageSize, that.pageSize) &&
-                Objects.equals(this.continuationToken, that.continuationToken);
+                Objects.equals(this.continuationToken, that.continuationToken) &&
+                Objects.equals(this.startTime, that.startTime);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, pageSize, continuationToken);
+        return Objects.hash(type, pageSize, continuationToken, startTime);
     }
 
     @Override
     public String toString() {
-        return "ExpandRequest[" +
+        return "ReadChangesRequest[" +
                 "type=" + type + ", " +
                 "pageSize=" + pageSize + ", " +
-                "continuationToken=" + continuationToken + ']';
+                "continuationToken=" + continuationToken + ", " +
+                "startTime=" + startTime + ']';
     }
 
 }

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadChangesResponse.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadChangesResponse.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkiverse.openfga.client.model.TupleChange;
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
 
-public final class ListChangesResponse {
+public final class ReadChangesResponse {
 
     private final List<TupleChange> changes;
 
@@ -22,7 +22,7 @@ public final class ListChangesResponse {
     private final String continuationToken;
 
     @JsonCreator(mode = PROPERTIES)
-    public ListChangesResponse(List<TupleChange> changes,
+    public ReadChangesResponse(List<TupleChange> changes,
             @JsonProperty("continuation_token") @Nullable String continuationToken) {
         this.changes = Preconditions.parameterNonNull(changes, "changes");
         this.continuationToken = continuationToken;
@@ -44,7 +44,7 @@ public final class ListChangesResponse {
             return true;
         if (obj == null || obj.getClass() != this.getClass())
             return false;
-        var that = (ListChangesResponse) obj;
+        var that = (ReadChangesResponse) obj;
         return Objects.equals(this.changes, that.changes) &&
                 Objects.equals(this.continuationToken, that.continuationToken);
     }

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/utils/ModelMapper.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/utils/ModelMapper.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.openfga.client.model.utils;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+
+public class ModelMapper {
+
+    public static final ObjectMapper mapper = new JsonMapper()
+            .registerModule(new JavaTimeModule())
+            .registerModule(new Jdk8Module())
+            .registerModule(new ParameterNamesModule())
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+}

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/utils/Preconditions.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/utils/Preconditions.java
@@ -3,8 +3,17 @@ package io.quarkiverse.openfga.client.model.utils;
 import java.util.Objects;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class Preconditions {
+
+    public static Integer parameterNullableRange(@Nullable Integer value, int min, int max, int defaultValue,
+            @Nonnull String name) {
+        if (value != null && (value < min || value > max)) {
+            throw new IllegalArgumentException(name + " must be between " + min + " and " + max);
+        }
+        return value != null ? value : defaultValue;
+    }
 
     public static <T> @Nonnull T parameterNonNull(@Nonnull T value, @Nonnull String name) {
         return Objects.requireNonNull(value, name + " parameter must not be null");

--- a/runtime/src/main/java/io/quarkiverse/openfga/client/AuthorizationModelsClient.java
+++ b/runtime/src/main/java/io/quarkiverse/openfga/client/AuthorizationModelsClient.java
@@ -8,9 +8,15 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 import io.quarkiverse.openfga.client.api.API;
-import io.quarkiverse.openfga.client.model.*;
-import io.quarkiverse.openfga.client.model.dto.*;
+import io.quarkiverse.openfga.client.model.AuthorizationModel;
+import io.quarkiverse.openfga.client.model.AuthorizationModelSchema;
+import io.quarkiverse.openfga.client.model.Condition;
+import io.quarkiverse.openfga.client.model.TypeDefinition;
+import io.quarkiverse.openfga.client.model.dto.ListAuthorizationModelsRequest;
+import io.quarkiverse.openfga.client.model.dto.WriteAuthorizationModelRequest;
+import io.quarkiverse.openfga.client.model.dto.WriteAuthorizationModelResponse;
 import io.quarkiverse.openfga.client.utils.PaginatedList;
+import io.quarkiverse.openfga.client.utils.Pagination;
 import io.smallrye.mutiny.Uni;
 
 public class AuthorizationModelsClient {
@@ -23,15 +29,23 @@ public class AuthorizationModelsClient {
         this.storeId = storeId;
     }
 
+    @Deprecated(since = "2.4.0", forRemoval = true)
     public Uni<PaginatedList<AuthorizationModel>> list(@Nullable Integer pageSize, @Nullable String pagingToken) {
+        return list(Pagination.limitedTo(pageSize).andContinuingFrom(pagingToken));
+    }
+
+    public Uni<PaginatedList<AuthorizationModel>> list() {
+        return list(Pagination.DEFAULT);
+    }
+
+    public Uni<PaginatedList<AuthorizationModel>> list(Pagination pagination) {
         return storeId.flatMap(storeId -> {
             var request = ListAuthorizationModelsRequest.builder()
-                    .pageSize(pageSize)
-                    .continuationToken(pagingToken)
+                    .pageSize(pagination.pageSize())
+                    .continuationToken(pagination.continuationToken())
                     .build();
             return api.listAuthorizationModels(storeId, request);
-        })
-                .map(res -> new PaginatedList<>(res.getAuthorizationModels(), res.getContinuationToken()));
+        }).map(res -> new PaginatedList<>(res.getAuthorizationModels(), res.getContinuationToken()));
     }
 
     public Uni<List<AuthorizationModel>> listAll() {

--- a/runtime/src/main/java/io/quarkiverse/openfga/client/StoreClient.java
+++ b/runtime/src/main/java/io/quarkiverse/openfga/client/StoreClient.java
@@ -2,6 +2,7 @@ package io.quarkiverse.openfga.client;
 
 import static io.quarkiverse.openfga.client.utils.PaginatedList.collectAllPages;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -11,10 +12,10 @@ import io.quarkiverse.openfga.client.model.Store;
 import io.quarkiverse.openfga.client.model.Tuple;
 import io.quarkiverse.openfga.client.model.TupleChange;
 import io.quarkiverse.openfga.client.model.dto.GetStoreResponse;
-import io.quarkiverse.openfga.client.model.dto.ListChangesRequest;
-import io.quarkiverse.openfga.client.model.dto.ListChangesResponse;
+import io.quarkiverse.openfga.client.model.dto.ReadChangesRequest;
 import io.quarkiverse.openfga.client.model.dto.ReadRequest;
 import io.quarkiverse.openfga.client.utils.PaginatedList;
+import io.quarkiverse.openfga.client.utils.Pagination;
 import io.smallrye.mutiny.Uni;
 
 public class StoreClient {
@@ -36,21 +37,80 @@ public class StoreClient {
         return storeId.flatMap(api::deleteStore);
     }
 
-    public Uni<List<TupleChange>> listChanges(@Nullable String type, @Nullable Integer pageSize,
-            @Nullable String continuationToken) {
-        var request = ListChangesRequest.builder()
-                .type(type)
-                .pageSize(pageSize)
-                .continuationToken(continuationToken)
-                .build();
-        return storeId.flatMap(storeId -> api.listChanges(storeId, request))
-                .map(ListChangesResponse::getChanges);
+    public record ReadChangesFilter(@Nullable String type, @Nullable OffsetDateTime startTime) {
+
+        public static final ReadChangesFilter ALL = new ReadChangesFilter(null, null);
+
+        public static ReadChangesFilter only(@Nullable String type) {
+            return new ReadChangesFilter(type, null);
+        }
+
+        public static ReadChangesFilter since(@Nullable OffsetDateTime startTime) {
+            return new ReadChangesFilter(null, startTime);
+        }
+
+        public ReadChangesFilter andOnly(@Nullable String type) {
+            return new ReadChangesFilter(type, this.startTime);
+        }
+
+        public ReadChangesFilter andSince(@Nullable OffsetDateTime startTime) {
+            return new ReadChangesFilter(this.type, startTime);
+        }
     }
 
+    @Deprecated(since = "2.4.0", forRemoval = true)
+    public Uni<List<TupleChange>> listChanges(@Nullable String type, @Nullable Integer pageSize,
+            @Nullable String continuationToken) {
+        return readChanges(
+                ReadChangesFilter.only(type),
+                Pagination.limitedTo(pageSize).andContinuingFrom(continuationToken))
+                .map(PaginatedList::getItems);
+    }
+
+    public Uni<PaginatedList<TupleChange>> readChanges() {
+        return readChanges(ReadChangesFilter.ALL, Pagination.DEFAULT);
+    }
+
+    public Uni<PaginatedList<TupleChange>> readChanges(ReadChangesFilter filter) {
+        return readChanges(filter, Pagination.DEFAULT);
+    }
+
+    public Uni<PaginatedList<TupleChange>> readChanges(Pagination pagination) {
+        return readChanges(ReadChangesFilter.ALL, pagination);
+    }
+
+    public Uni<PaginatedList<TupleChange>> readChanges(ReadChangesFilter filter, Pagination pagination) {
+        var request = ReadChangesRequest.builder()
+                .type(filter.type)
+                .startTime(filter.startTime)
+                .pageSize(pagination.pageSize())
+                .continuationToken(pagination.continuationToken())
+                .build();
+        return storeId.flatMap(storeId -> api.readChanges(storeId, request))
+                .map(res -> new PaginatedList<>(res.getChanges(), res.getContinuationToken()));
+    }
+
+    public Uni<List<TupleChange>> readAllChanges() {
+        return readAllChanges(null);
+    }
+
+    public Uni<List<TupleChange>> readAllChanges(@Nullable Integer pageSize) {
+        return collectAllPages(pageSize, this::readChanges);
+    }
+
+    @Deprecated(since = "2.4.0", forRemoval = true)
     public Uni<PaginatedList<Tuple>> readTuples(@Nullable Integer pageSize, @Nullable String continuationToken) {
+        return readTuples(Pagination.limitedTo(pageSize).andContinuingFrom(continuationToken));
+    }
+
+    public Uni<PaginatedList<Tuple>> readTuples() {
+        return readTuples(Pagination.DEFAULT);
+    }
+
+    public Uni<PaginatedList<Tuple>> readTuples(Pagination pagination) {
         var request = ReadRequest.builder()
-                .pageSize(pageSize)
-                .continuationToken(continuationToken)
+                .pageSize(pagination.pageSize())
+                .continuationToken(pagination.continuationToken())
                 .build();
         return storeId.flatMap(storeId -> api.read(storeId, request))
                 .map(res -> new PaginatedList<>(res.getTuples(), res.getContinuationToken()));
@@ -66,10 +126,6 @@ public class StoreClient {
 
     public AuthorizationModelsClient authorizationModels() {
         return new AuthorizationModelsClient(api, storeId);
-    }
-
-    public AssertionsClient assertions(String authorizationModelId) {
-        return new AssertionsClient(api, storeId.map(storeId -> new ClientConfig(storeId, authorizationModelId)));
     }
 
 }

--- a/runtime/src/main/java/io/quarkiverse/openfga/client/api/Queries.java
+++ b/runtime/src/main/java/io/quarkiverse/openfga/client/api/Queries.java
@@ -23,12 +23,21 @@ public class Queries {
         return map;
     }
 
-    public static <V1, V2> Map<String, String> query(String key1, @Nullable V1 value1, String key2, @Nullable V2 value2,
+    public static <V1, V2, V3> Map<String, String> query(String key1, @Nullable V1 value1, String key2, @Nullable V2 value2,
             String key3,
-            @Nullable V2 value3) {
+            @Nullable V3 value3) {
         var map = query(key1, value1, key2, value2);
         if (value3 != null) {
             map.put(key3, value3.toString());
+        }
+        return map;
+    }
+
+    public static <V1, V2, V3, V4> Map<String, String> query(String key1, @Nullable V1 value1, String key2, @Nullable V2 value2,
+            String key3, @Nullable V3 value3, String key4, @Nullable V4 value4) {
+        var map = query(key1, value1, key2, value2, key3, value3);
+        if (value4 != null) {
+            map.put(key4, value4.toString());
         }
         return map;
     }

--- a/runtime/src/main/java/io/quarkiverse/openfga/client/utils/PaginatedList.java
+++ b/runtime/src/main/java/io/quarkiverse/openfga/client/utils/PaginatedList.java
@@ -3,7 +3,7 @@ package io.quarkiverse.openfga.client.utils;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
@@ -12,6 +12,7 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
 public final class PaginatedList<T> {
+
     private final List<T> items;
     @Nullable
     private final String token;
@@ -26,12 +27,12 @@ public final class PaginatedList<T> {
     }
 
     public static <T> Uni<List<T>> collectAllPages(@Nullable Integer pageSize,
-            BiFunction<Integer, String, Uni<PaginatedList<T>>> listGenerator) {
+            Function<Pagination, Uni<PaginatedList<T>>> listGenerator) {
         return Multi.createBy()
-                .repeating().uni(AtomicReference<String>::new, lastToken -> {
-                    return listGenerator.apply(pageSize, lastToken.get())
-                            .onItem().invoke(list -> lastToken.set(list.getToken()));
-                })
+                .repeating()
+                .uni(AtomicReference<String>::new,
+                        lastToken -> listGenerator.apply(new Pagination(pageSize, lastToken.get()))
+                                .onItem().invoke(list -> lastToken.set(list.getToken())))
                 .whilst(PaginatedList::isNotLastPage)
                 .onItem().transformToIterable(PaginatedList::getItems)
                 .collect().asList();
@@ -52,7 +53,7 @@ public final class PaginatedList<T> {
             return true;
         if (obj == null || obj.getClass() != this.getClass())
             return false;
-        var that = (PaginatedList) obj;
+        var that = (PaginatedList<?>) obj;
         return Objects.equals(this.items, that.items) &&
                 Objects.equals(this.token, that.token);
     }

--- a/runtime/src/main/java/io/quarkiverse/openfga/client/utils/Pagination.java
+++ b/runtime/src/main/java/io/quarkiverse/openfga/client/utils/Pagination.java
@@ -1,0 +1,30 @@
+package io.quarkiverse.openfga.client.utils;
+
+import javax.annotation.Nullable;
+
+import io.quarkiverse.openfga.client.model.utils.Preconditions;
+
+public record Pagination(@Nullable Integer pageSize, @Nullable String continuationToken) {
+
+    public static final Pagination DEFAULT = new Pagination(null, null);
+
+    public Pagination {
+        pageSize = Preconditions.parameterNullableRange(pageSize, 1, 100, 10, "pageSize");
+    }
+
+    public static Pagination limitedTo(@Nullable Integer pageSize) {
+        return new Pagination(pageSize, null);
+    }
+
+    public static Pagination continuingFrom(@Nullable String continuationToken) {
+        return new Pagination(null, continuationToken);
+    }
+
+    public Pagination andLimitedTo(@Nullable Integer pageSize) {
+        return new Pagination(pageSize, continuationToken);
+    }
+
+    public Pagination andContinuingFrom(@Nullable String continuationToken) {
+        return new Pagination(pageSize, continuationToken);
+    }
+}


### PR DESCRIPTION
* Fixes multiple endpoints that were not getting query parameters passed
* Deprecates and replaces multi-parameter methods with option classes
* * Uses a common `Pagination` class for all paginated endpoints
* * Adds endpoint specific classes for filtering and other options
* Adds tests for endpoints with pagination and filtering pagination parameters

Fixes #177 