### PR TITLE
Prefer `isPropertyNonEmpty` on url for devservice startup

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/openfga/deployment/DevServicesOpenFGAProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/openfga/deployment/DevServicesOpenFGAProcessor.java
@@ -167,7 +167,7 @@ public class DevServicesOpenFGAProcessor {
             return null;
         }
 
-        boolean needToStart = !ConfigUtils.isPropertyPresent(URL_CONFIG_KEY);
+        boolean needToStart = !ConfigUtils.isPropertyNonEmpty(URL_CONFIG_KEY);
         if (!needToStart) {
             log.debug("Not starting devservices for default OpenFGA client as url has been provided");
             return null;


### PR DESCRIPTION
For url, `isPropertyNonEmpty` is a better way to check whether the dev service should start up because it allows to set the value in the default profile and override it in dev/tests only.

For example, one can not do this currently:

application.properties
```yaml
quarkus.openfga.url=http://some-openfga-server.com

%dev.quarkus.openfga.url=
```

Or a pretty common pattern:
```
quarkus.openfga.url=${FGA_URL:}
```

This PR would make such examples work. Note that there's no way in Quarkus to unset the value of the default profile, you can just set it to empty. Therefore the only option ends up being specifying it both in a `prod` and test/dev profile, but you can't make use of the default profile.