### PR TITLE
🐛 Fix comparison of store and local schema

### DIFF
--- a/model/src/main/java/io/quarkiverse/openfga/client/model/Schema.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/Schema.java
@@ -1026,6 +1026,10 @@ public interface Schema {
     }
 
     record ObjectRelation(@Nullable String object, @Nullable String relation) {
+        public ObjectRelation(@Nullable String object, @Nullable String relation) {
+            this.object = object == null ? "" : object;
+            this.relation = relation;
+        }
     }
 
     static UsersetTree usersetTree(UsersetTree.Node root) {


### PR DESCRIPTION
## Desciption
Fixes an issue, when you run multiple instances of quarkus with the same openfga authorization schema.

### Current behavior
Openfga failes with a `ConfigurationException` "Could not find authorization model in shared DevServices instance"
Comparison of ObjectRelation failing, because it compares `null` with `empty String`.

### Expected behavior
Openfga starts up and finds the authorization schema, which is already present.
Comparison works fine for ObjectRelation, either compare `null` with `null` or `empty String` with `empty String`
