### PR TITLE
Translate empty strings & containers in authorization model to null

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/openfga/test/AuthorizationModelClientTest.java
+++ b/deployment/src/test/java/io/quarkiverse/openfga/test/AuthorizationModelClientTest.java
@@ -72,6 +72,21 @@ public class AuthorizationModelClientTest {
     }
 
     @Test
+    @DisplayName("Returned Schema Matches")
+    public void testSchemaMatches() {
+        var model = authorizationModelClient.get()
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
+                .awaitItem()
+                .getItem();
+        assertThat(model.getSchemaVersion())
+                .isEqualTo(SchemaFixtures.schema.getSchemaVersion());
+        assertThat(model.getTypeDefinitions())
+                .isEqualTo(SchemaFixtures.schema.getTypeDefinitions());
+        assertThat(model.getConditions())
+                .isEqualTo(SchemaFixtures.schema.getConditions());
+    }
+
+    @Test
     @DisplayName("Read & Write Tuples")
     public void readWriteTuples() {
 

--- a/deployment/src/test/java/io/quarkiverse/openfga/test/AuthorizationModelsClientTest.java
+++ b/deployment/src/test/java/io/quarkiverse/openfga/test/AuthorizationModelsClientTest.java
@@ -100,8 +100,8 @@ public class AuthorizationModelsClientTest {
                             .extracting(AuthorizationModel::getTypeDefinitions, as(iterable(TypeDefinition.class)))
                             .containsExactlyInAnyOrderElementsOf(SchemaFixtures.schema.getTypeDefinitions());
                     assertThat(model)
-                            .extracting(AuthorizationModel::getConditions, as(map(String.class, Condition.class)))
-                            .isEmpty();
+                            .extracting(AuthorizationModel::getConditions)
+                            .isNull();
                 });
     }
 
@@ -130,8 +130,8 @@ public class AuthorizationModelsClientTest {
                             .extracting(AuthorizationModel::getTypeDefinitions, as(iterable(TypeDefinition.class)))
                             .containsExactlyInAnyOrderElementsOf(SchemaFixtures.schema.getTypeDefinitions());
                     assertThat(model)
-                            .extracting(AuthorizationModel::getConditions, as(map(String.class, Condition.class)))
-                            .isEmpty();
+                            .extracting(AuthorizationModel::getConditions)
+                            .isNull();
                 });
         assertThat(page1)
                 .extracting(PaginatedList::getToken, as(STRING))
@@ -156,8 +156,8 @@ public class AuthorizationModelsClientTest {
                             .extracting(AuthorizationModel::getTypeDefinitions, as(iterable(TypeDefinition.class)))
                             .containsExactlyInAnyOrderElementsOf(SchemaFixtures.schema.getTypeDefinitions());
                     assertThat(model)
-                            .extracting(AuthorizationModel::getConditions, as(map(String.class, Condition.class)))
-                            .isEmpty();
+                            .extracting(AuthorizationModel::getConditions)
+                            .isNull();
                 });
         assertThat(page2)
                 .extracting(PaginatedList::getToken, as(STRING))
@@ -182,8 +182,8 @@ public class AuthorizationModelsClientTest {
                             .extracting(AuthorizationModel::getTypeDefinitions, as(iterable(TypeDefinition.class)))
                             .containsExactlyInAnyOrderElementsOf(SchemaFixtures.schema.getTypeDefinitions());
                     assertThat(model)
-                            .extracting(AuthorizationModel::getConditions, as(map(String.class, Condition.class)))
-                            .isEmpty();
+                            .extracting(AuthorizationModel::getConditions)
+                            .isNull();
                 });
         assertThat(page3)
                 .extracting(PaginatedList::getToken, as(STRING))
@@ -234,8 +234,8 @@ public class AuthorizationModelsClientTest {
                             .extracting(AuthorizationModel::getTypeDefinitions, as(iterable(TypeDefinition.class)))
                             .containsExactlyInAnyOrderElementsOf(SchemaFixtures.schema.getTypeDefinitions());
                     assertThat(model)
-                            .extracting(AuthorizationModel::getConditions, as(map(String.class, Condition.class)))
-                            .isEmpty();
+                            .extracting(AuthorizationModel::getConditions)
+                            .isNull();
                 });
     }
 
@@ -267,8 +267,8 @@ public class AuthorizationModelsClientTest {
                             .extracting(AuthorizationModel::getTypeDefinitions, as(iterable(TypeDefinition.class)))
                             .containsExactlyInAnyOrderElementsOf(SchemaFixtures.schema.getTypeDefinitions());
                     assertThat(model)
-                            .extracting(AuthorizationModel::getConditions, as(map(String.class, Condition.class)))
-                            .isEmpty();
+                            .extracting(AuthorizationModel::getConditions)
+                            .isNull();
                 });
     }
 

--- a/docs/modules/ROOT/pages/includes/quarkus-openfga-client.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-openfga-client.adoc
@@ -742,9 +742,9 @@ endif::add-copy-button-to-config-props[]
 --
 Credentials method to use for authentication.
 
-When set to `preshared`, the required `quarkus.openfga.credentials.preshared.++*++` keys must be provided.
+When set to `preshared`, the required `preshared` configuration keys must be provided.
 
-When set to `oidc`, the required `quarkus.openfga.credentials.oidc.++*++` keys must be provided.
+When set to `oidc`, the required `oidc` configuration keys must be provided.
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/includes/quarkus-openfga-client_quarkus.openfga.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-openfga-client_quarkus.openfga.adoc
@@ -742,9 +742,9 @@ endif::add-copy-button-to-config-props[]
 --
 Credentials method to use for authentication.
 
-When set to `preshared`, the required `quarkus.openfga.credentials.preshared.++*++` keys must be provided.
+When set to `preshared`, the required `preshared` configuration keys must be provided.
 
-When set to `oidc`, the required `quarkus.openfga.credentials.oidc.++*++` keys must be provided.
+When set to `oidc`, the required `oidc` configuration keys must be provided.
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/AuthorizationModel.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/AuthorizationModel.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.quarkiverse.openfga.client.model.Schema.Condition;
 import io.quarkiverse.openfga.client.model.Schema.TypeDefinition;
+import io.quarkiverse.openfga.client.model.utils.Maps;
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
 
 public final class AuthorizationModel {
@@ -33,7 +34,7 @@ public final class AuthorizationModel {
         this.id = Preconditions.parameterNonNull(id, "id");
         this.schemaVersion = Preconditions.parameterNonNull(schemaVersion, "schemaVersion");
         this.typeDefinitions = Preconditions.parameterNonNull(typeDefinitions, "typeDefinitions");
-        this.conditions = conditions;
+        this.conditions = Maps.emptyToNull(conditions);
     }
 
     public String getId() {

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/AuthorizationModelSchema.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/AuthorizationModelSchema.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.quarkiverse.openfga.client.model.Schema.Condition;
 import io.quarkiverse.openfga.client.model.Schema.TypeDefinition;
+import io.quarkiverse.openfga.client.model.utils.Maps;
 import io.quarkiverse.openfga.client.model.utils.ModelMapper;
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
 
@@ -104,7 +105,7 @@ public final class AuthorizationModelSchema {
             @Nullable Map<String, Condition> conditions) {
         this.schemaVersion = schemaVersion;
         this.typeDefinitions = Preconditions.parameterNonNull(typeDefinitions, "typeDefinitions");
-        this.conditions = conditions;
+        this.conditions = Maps.emptyToNull(conditions);
     }
 
     @JsonProperty("schema_version")

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/Schema.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/Schema.java
@@ -1026,6 +1026,10 @@ public interface Schema {
     }
 
     record ObjectRelation(@Nullable String object, @Nullable String relation) {
+        public ObjectRelation(@Nullable String object, @Nullable String relation) {
+            this.object = Strings.emptyToNull(object);
+            this.relation = Strings.emptyToNull(relation);
+        }
     }
 
     static UsersetTree usersetTree(UsersetTree.Node root) {

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/utils/Maps.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/utils/Maps.java
@@ -1,0 +1,13 @@
+package io.quarkiverse.openfga.client.model.utils;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+public class Maps {
+
+    public static <K, V> @Nullable Map<K, V> emptyToNull(@Nullable Map<K, V> map) {
+        return map == null || map.isEmpty() ? null : map;
+    }
+
+}

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/utils/Strings.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/utils/Strings.java
@@ -4,7 +4,7 @@ import javax.annotation.Nullable;
 
 public final class Strings {
 
-    public static String emptyToNull(@Nullable String string) {
+    public static @Nullable String emptyToNull(@Nullable String string) {
         return string == null || string.isEmpty() ? null : string;
     }
 


### PR DESCRIPTION
Ensures `TypeDefinition` compare by mapping empty nullable fields to null. This is in keeping with how all the types are managed (as opposed to #215 which maps null to empty for  `ObjectRelation` only.

Closes #215 
