### PR TITLE
Update OpenFGA client to support 1.11-1.18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,5 +62,13 @@ jobs:
           OKTA_FGA_CLIENT_SECRET: ${{ secrets.OKTA_FGA_CLIENT_SECRET || '--not-set--' }}
         run: mvn -B clean install -Dno-format
 
+      - name: Test OpenFGA 1.11 compatibility
+        run: >-
+          mvn -B -pl deployment test -Dno-format
+          -Dquarkus.openfga.devservices.image-name=openfga/openfga:v1.11.6
+
+      - name: Check 3.14 binary compatibility
+        run: mvn -B -pl model,runtime -am verify -Pbinary-compatibility -Dno-format -DskipTests
+
       - name: Build with Maven (Native)
         run: mvn -B install -Dnative -Dquarkus.native.container-build -Dnative.surefire.skip

--- a/deployment/src/main/java/io/quarkiverse/openfga/deployment/DevServicesOpenFGAProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/openfga/deployment/DevServicesOpenFGAProcessor.java
@@ -81,7 +81,7 @@ public class DevServicesOpenFGAProcessor {
 
     private static final Logger log = Logger.getLogger(DevServicesOpenFGAProcessor.class);
 
-    public static final String OPEN_FGA_VERSION = "v1.12.1";
+    public static final String OPEN_FGA_VERSION = "v1.18.3";
     public static final String OPEN_FGA_IMAGE_NAME = "openfga/openfga";
     public static final String OPEN_FGA_IMAGE = OPEN_FGA_IMAGE_NAME + ":" + OPEN_FGA_VERSION;
     public static final String DEV_SERVICE_LABEL = "quarkus-dev-service-openfga";

--- a/deployment/src/test/java/io/quarkiverse/openfga/test/AuthorizationModelClientTest.java
+++ b/deployment/src/test/java/io/quarkiverse/openfga/test/AuthorizationModelClientTest.java
@@ -29,8 +29,10 @@ import io.quarkiverse.openfga.client.model.*;
 import io.quarkiverse.openfga.client.utils.PaginatedList;
 import io.quarkiverse.openfga.client.utils.Pagination;
 import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 
+@SuppressWarnings("removal")
 public class AuthorizationModelClientTest {
 
     // Start unit test with extension loaded
@@ -175,6 +177,23 @@ public class AuthorizationModelClientTest {
     }
 
     @Test
+    @DisplayName("Detailed Check Returns Check Response")
+    public void detailedCheckReturnsCheckResponse() {
+        var tupleDef = document123.define(RelationshipNames.READER, userMe);
+
+        authorizationModelClient.write(tupleDef)
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
+                .awaitItem();
+
+        var response = authorizationModelClient.checkDetailed(tupleDef)
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
+                .awaitItem()
+                .getItem();
+
+        assertThat(response.allowed()).isTrue();
+    }
+
+    @Test
     @DisplayName("Check With Contextual Tuples")
     public void checkWithContextualTuples() {
 
@@ -277,7 +296,8 @@ public class AuthorizationModelClientTest {
                                         .isEqualTo(ErrorCode.VALIDATION_ERROR);
                                 assertThat(e)
                                         .extracting(CheckError::message)
-                                        .isEqualTo("the 'user' field is malformed");
+                                        .asString()
+                                        .endsWith("the 'user' field is malformed");
                             });
                 });
     }
@@ -687,6 +707,43 @@ public class AuthorizationModelClientTest {
                 .getItem();
         assertThat(objects)
                 .containsOnly(document123, document456);
+    }
+
+    @Test
+    @DisplayName("Stream Objects Matching Object Type, Relation, and User")
+    public void streamObjectsMatchingObjectTypeRelationAndUser() {
+        var aTupleDef = document123.define(RelationshipNames.WRITER, userMe);
+        var bTupleDef = document456.define(RelationshipNames.WRITER, userMe);
+        var cTupleDef = document456.define(RelationshipNames.WRITER, userYou);
+
+        authorizationModelClient.write(aTupleDef, bTupleDef, cTupleDef)
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
+                .awaitItem();
+
+        var subscriber = authorizationModelClient.streamObjects(ListObjectsFilter.byObjectType(documentType)
+                .relation(RelationshipNames.WRITER)
+                .user(userMe))
+                .subscribe().withSubscriber(AssertSubscriber.create(2));
+
+        subscriber.awaitCompletion(ofSeconds(10))
+                .assertCompleted();
+        assertThat(subscriber.getItems()).containsOnly(document123, document456);
+    }
+
+    @Test
+    @DisplayName("Can Ignore Write Conflicts")
+    public void canIgnoreWriteConflicts() {
+        var tupleDef = document123.define(RelationshipNames.WRITER, userMe);
+
+        authorizationModelClient.write(tupleDef)
+                .flatMap(ignored -> authorizationModelClient.write(List.of(tupleDef),
+                        WriteOptions.withOnDuplicate(WriteConflictBehavior.IGNORE)))
+                .flatMap(ignored -> authorizationModelClient.delete(List.of(tupleDef)))
+                .flatMap(ignored -> authorizationModelClient.delete(List.of(tupleDef),
+                        WriteOptions.withOnMissing(WriteConflictBehavior.IGNORE)))
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
+                .awaitItem()
+                .assertCompleted();
     }
 
     @Test

--- a/deployment/src/test/java/io/quarkiverse/openfga/test/DefaultAuthorizationModelClientTest.java
+++ b/deployment/src/test/java/io/quarkiverse/openfga/test/DefaultAuthorizationModelClientTest.java
@@ -30,6 +30,7 @@ import io.quarkiverse.openfga.client.utils.PaginatedList;
 import io.quarkus.test.QuarkusUnitTest;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 
+@SuppressWarnings("removal")
 public class DefaultAuthorizationModelClientTest {
 
     // Start unit test with extension loaded

--- a/deployment/src/test/java/io/quarkiverse/openfga/test/StoreClientTest.java
+++ b/deployment/src/test/java/io/quarkiverse/openfga/test/StoreClientTest.java
@@ -24,6 +24,7 @@ import io.quarkiverse.openfga.client.AuthorizationModelClient;
 import io.quarkiverse.openfga.client.OpenFGAClient;
 import io.quarkiverse.openfga.client.StoreClient;
 import io.quarkiverse.openfga.client.StoreClient.ReadChangesFilter;
+import io.quarkiverse.openfga.client.StoreClient.ReadTuplesFilter;
 import io.quarkiverse.openfga.client.model.*;
 import io.quarkiverse.openfga.client.utils.Pagination;
 import io.quarkiverse.openfga.test.SchemaFixtures.RelationshipNames;
@@ -280,6 +281,27 @@ public class StoreClientTest {
                         tuple(docTuple4.conditional(), TupleOperation.WRITE),
                         tuple(docTuple5.conditional(), TupleOperation.WRITE),
                         tuple(docTuple6.conditional(), TupleOperation.WRITE));
+    }
+
+    @Test
+    @DisplayName("Can Read Filtered Tuples From Store")
+    public void canReadFilteredTuplesFromStore() {
+        var authorizationModelClient = initializeAuthorizationModel();
+        var matchingTuple = document123.define(RelationshipNames.READER, userMe);
+        var otherTuple = document456.define(RelationshipNames.READER, userYou);
+
+        authorizationModelClient.write(matchingTuple, otherTuple)
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
+                .awaitItem();
+
+        var tuples = storeClient.readAllTuples(ReadTuplesFilter.byObject(document123))
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
+                .awaitItem()
+                .getItem();
+
+        assertThat(tuples)
+                .extracting(RelTuple::getKey)
+                .containsExactly(matchingTuple.conditional());
     }
 
     @Test

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -194,6 +194,41 @@ The extension provides three injectable clients for accessing the configured ins
 `AuthorizationModelsClient`:: Manage (list, create, delete) authorization models and create `AuthorizationModelClient` instances for accessing a specific model.
 `AuthorizationModelClient`:: Access authorization model configured via `quarkus.openfga.authoriztion-model-id` or the default model if none is configured.
 
+=== OpenFGA API alignment in 3.15
+
+Tuple reads are store-scoped in OpenFGA. Use `StoreClient.readTuples(...)` or
+`StoreClient.readAllTuples(...)` for new code. The existing `AuthorizationModelClient.read(...)` and `readAll(...)`
+methods remain functional in 3.15 for source and binary compatibility, but are deprecated for removal in 4.0.
+
+[source,java]
+----
+var tuples = storeClient.readAllTuples(
+        StoreClient.ReadTuplesFilter.byObject("document:roadmap"));
+----
+
+`AuthorizationModelClient` also exposes the OpenFGA operations and options added since the client's previous API
+snapshot:
+
+* `checkDetailed(...)` returns the complete `CheckResponse`, including resolution details requested from OpenFGA.
+* `streamObjects(...)` returns a back-pressure-aware Mutiny `Multi<RelObject>` from Streamed List Objects.
+* `WriteOptions` configures `on_duplicate` and `on_missing` behavior for idempotent tuple writes and deletes.
+
+[source,java]
+----
+var objects = authorizationModelClient.streamObjects(
+        AuthorizationModelClient.ListObjectsFilter.byObjectType("document")
+                .relation("viewer")
+                .user("user:anne"));
+
+var writeOptions = AuthorizationModelClient.WriteOptions
+        .withOnDuplicate(WriteConflictBehavior.IGNORE)
+        .onMissing(WriteConflictBehavior.IGNORE);
+----
+
+OpenFGA does not define `authorization_model_id` in Read request bodies or `context` in Expand request bodies.
+The corresponding compatibility properties remain available in 3.15 but are no longer serialized. Assertion model
+IDs continue to be passed in the assertion endpoint path and are not included in the request body.
+
 == Examples
 
 === Write a Relationship Tuple

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/Assertion.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/Assertion.java
@@ -51,7 +51,6 @@ public final class Assertion {
     }
 
     @JsonProperty("contextual_tuples")
-    @JsonSerialize(typing = JsonSerialize.Typing.STATIC)
     @Nullable
     public Collection<RelTupleKeyed> getContextualTuples() {
         return contextualTuples;
@@ -68,12 +67,13 @@ public final class Assertion {
             return false;
         return Objects.equals(this.tupleKey, that.tupleKey) &&
                 this.expectation == that.expectation &&
-                Objects.equals(this.contextualTuples, that.contextualTuples);
+                Objects.equals(this.contextualTuples, that.contextualTuples) &&
+                Objects.equals(this.context, that.context);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(tupleKey, expectation, contextualTuples);
+        return Objects.hash(tupleKey, expectation, contextualTuples, context);
     }
 
     @Override
@@ -81,7 +81,8 @@ public final class Assertion {
         return "Assertion[" +
                 "tupleKey=" + tupleKey + ", " +
                 "expectation=" + expectation + ", " +
-                "contextualTuples=" + contextualTuples + ']';
+                "contextualTuples=" + contextualTuples + ", " +
+                "context=" + context + ']';
     }
 
 }

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/Check.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/Check.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
 
@@ -19,7 +20,7 @@ import io.quarkiverse.openfga.client.model.utils.Preconditions;
  * The additional context is used to provide additional data to the check, and is used to resolve
  * the parameters of the check.
  */
-public record Check(@JsonProperty("tuple_key") RelTupleKeyed tupleKey,
+public record Check(@JsonProperty("tuple_key") @JsonSerialize(typing = JsonSerialize.Typing.STATIC) RelTupleKeyed tupleKey,
         @JsonProperty("contextual_tuples") @Nullable RelTupleKeys contextualTuples,
         @Nullable Map<String, Object> context,
         @JsonProperty("correlation_id") String correlationId) {

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/FGAStreamException.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/FGAStreamException.java
@@ -1,0 +1,48 @@
+package io.quarkiverse.openfga.client.model;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+/**
+ * Reports an error embedded in an OpenFGA streaming response.
+ */
+public final class FGAStreamException extends FGAException {
+
+    @Nullable
+    private final Integer code;
+    private final List<Map<String, Object>> details;
+
+    /**
+     * Creates a streaming response exception.
+     *
+     * @param code optional status code
+     * @param message optional status message
+     * @param details status details
+     */
+    public FGAStreamException(@Nullable Integer code, @Nullable String message, List<Map<String, Object>> details) {
+        super(message == null || message.isBlank() ? "OpenFGA stream failed" : message);
+        this.code = code;
+        this.details = List.copyOf(details);
+    }
+
+    /**
+     * Returns the status code supplied by OpenFGA.
+     *
+     * @return status code, or {@code null}
+     */
+    @Nullable
+    public Integer getCode() {
+        return code;
+    }
+
+    /**
+     * Returns immutable status detail objects.
+     *
+     * @return status details
+     */
+    public List<Map<String, Object>> getDetails() {
+        return details;
+    }
+}

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/WriteConflictBehavior.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/WriteConflictBehavior.java
@@ -1,0 +1,48 @@
+package io.quarkiverse.openfga.client.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Controls how OpenFGA handles duplicate writes or deletes of missing tuples.
+ */
+public enum WriteConflictBehavior {
+
+    ERROR("error"),
+
+    IGNORE("ignore"),
+
+    UNKNOWN("unknown");
+
+    private final String value;
+
+    WriteConflictBehavior(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns the OpenFGA wire value.
+     *
+     * @return wire value
+     */
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Resolves an OpenFGA wire value.
+     *
+     * @param value wire value
+     * @return matching behavior, or {@link #UNKNOWN}
+     */
+    @JsonCreator
+    public static WriteConflictBehavior fromValue(String value) {
+        for (var behavior : values()) {
+            if (behavior.value.equals(value)) {
+                return behavior;
+            }
+        }
+        return UNKNOWN;
+    }
+}

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ExpandRequest.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ExpandRequest.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
@@ -49,6 +50,14 @@ public final class ExpandRequest {
             return this;
         }
 
+        /**
+         * Sets compatibility-only context that is retained locally but is not sent to OpenFGA.
+         *
+         * @param context ignored request context
+         * @return this builder
+         * @deprecated the OpenFGA Expand API does not accept request context
+         */
+        @Deprecated(since = "3.15", forRemoval = true)
         public Builder context(@Nullable Map<String, Object> context) {
             this.context = context;
             return this;
@@ -113,6 +122,14 @@ public final class ExpandRequest {
         return contextualTuples;
     }
 
+    /**
+     * Returns compatibility-only context that is not serialized.
+     *
+     * @return ignored request context
+     * @deprecated the OpenFGA Expand API does not accept request context
+     */
+    @JsonIgnore
+    @Deprecated(since = "3.15", forRemoval = true)
     @Nullable
     public Map<String, Object> getContext() {
         return context;
@@ -129,12 +146,14 @@ public final class ExpandRequest {
             return false;
         return Objects.equals(this.tupleKey, that.tupleKey) &&
                 Objects.equals(this.authorizationModelId, that.authorizationModelId) &&
+                Objects.equals(this.contextualTuples, that.contextualTuples) &&
+                Objects.equals(this.context, that.context) &&
                 Objects.equals(this.consistency, that.consistency);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(tupleKey, authorizationModelId, consistency);
+        return Objects.hash(tupleKey, authorizationModelId, contextualTuples, context, consistency);
     }
 
     @Override
@@ -142,6 +161,8 @@ public final class ExpandRequest {
         return "ExpandRequest[" +
                 "tupleKey=" + tupleKey + ", " +
                 "authorizationModelId=" + authorizationModelId + ", " +
+                "contextualTuples=" + contextualTuples + ", " +
+                "context=" + context + ", " +
                 "consistency=" + consistency + ']';
     }
 

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadRequest.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/ReadRequest.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.quarkiverse.openfga.client.model.*;
@@ -126,6 +127,8 @@ public final class ReadRequest {
         private Integer pageSize;
         @Nullable
         private String continuationToken;
+        @Nullable
+        private ConsistencyPreference consistency;
 
         private Builder() {
         }
@@ -139,6 +142,14 @@ public final class ReadRequest {
             return this;
         }
 
+        /**
+         * Sets an authorization model ID that is retained for source compatibility but is not sent to OpenFGA.
+         *
+         * @param authorizationModelId ignored authorization model ID
+         * @return this builder
+         * @deprecated the OpenFGA Read API is store-scoped and does not accept an authorization model ID
+         */
+        @Deprecated(since = "3.15", forRemoval = true)
         public Builder authorizationModelId(@Nullable String authorizationModelId) {
             this.authorizationModelId = authorizationModelId;
             return this;
@@ -154,8 +165,19 @@ public final class ReadRequest {
             return this;
         }
 
+        /**
+         * Sets the consistency preference for the read.
+         *
+         * @param consistency consistency preference
+         * @return this builder
+         */
+        public Builder consistency(@Nullable ConsistencyPreference consistency) {
+            this.consistency = consistency;
+            return this;
+        }
+
         public ReadRequest build() {
-            return new ReadRequest(tupleKey, authorizationModelId, pageSize, continuationToken);
+            return new ReadRequest(tupleKey, authorizationModelId, pageSize, continuationToken, consistency);
         }
     }
 
@@ -171,16 +193,20 @@ public final class ReadRequest {
     private final Integer pageSize;
     @Nullable
     private final String continuationToken;
+    @Nullable
+    private final ConsistencyPreference consistency;
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     ReadRequest(@JsonProperty("tuple_key") @Nullable TupleKeyFilter tupleKey,
             @JsonProperty("authorization_model_id") @Nullable String authorizationModelId,
             @JsonProperty("page_size") @Nullable Integer pageSize,
-            @JsonProperty("continuation_token") @Nullable String continuationToken) {
+            @JsonProperty("continuation_token") @Nullable String continuationToken,
+            @Nullable ConsistencyPreference consistency) {
         this.tupleKey = tupleKey;
         this.authorizationModelId = authorizationModelId;
         this.pageSize = pageSize;
         this.continuationToken = continuationToken;
+        this.consistency = consistency;
     }
 
     @JsonProperty("tuple_key")
@@ -189,7 +215,14 @@ public final class ReadRequest {
         return tupleKey;
     }
 
-    @JsonProperty("authorization_model_id")
+    /**
+     * Returns the compatibility-only authorization model ID, which is not serialized.
+     *
+     * @return ignored authorization model ID
+     * @deprecated the OpenFGA Read API is store-scoped and does not accept an authorization model ID
+     */
+    @JsonIgnore
+    @Deprecated(since = "3.15", forRemoval = true)
     @Nullable
     public String getAuthorizationModelId() {
         return authorizationModelId;
@@ -207,18 +240,30 @@ public final class ReadRequest {
         return continuationToken;
     }
 
+    /**
+     * Returns the consistency preference for the read.
+     *
+     * @return consistency preference, or {@code null} for the server default
+     */
+    @Nullable
+    public ConsistencyPreference getConsistency() {
+        return consistency;
+    }
+
     @Override
     public boolean equals(@Nullable Object obj) {
         if (!(obj instanceof ReadRequest that))
             return false;
         return Objects.equals(tupleKey, that.tupleKey)
                 && Objects.equals(authorizationModelId, that.authorizationModelId)
-                && Objects.equals(pageSize, that.pageSize) && Objects.equals(continuationToken, that.continuationToken);
+                && Objects.equals(pageSize, that.pageSize)
+                && Objects.equals(continuationToken, that.continuationToken)
+                && Objects.equals(consistency, that.consistency);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(tupleKey, authorizationModelId, pageSize, continuationToken);
+        return Objects.hash(tupleKey, authorizationModelId, pageSize, continuationToken, consistency);
     }
 
     @Override
@@ -227,6 +272,7 @@ public final class ReadRequest {
                 "tupleKey=" + tupleKey + ", " +
                 "authorizationModelId=" + authorizationModelId + ", " +
                 "pageSize=" + pageSize + ", " +
-                "continuationToken=" + continuationToken + ']';
+                "continuationToken=" + continuationToken + ", " +
+                "consistency=" + consistency + ']';
     }
 }

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/StreamedListObjectsResponse.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/StreamedListObjectsResponse.java
@@ -1,0 +1,16 @@
+package io.quarkiverse.openfga.client.model.dto;
+
+import io.quarkiverse.openfga.client.model.RelObject;
+import io.quarkiverse.openfga.client.model.utils.Preconditions;
+
+/**
+ * A single object emitted by the OpenFGA streamed list-objects operation.
+ *
+ * @param object related object
+ */
+public record StreamedListObjectsResponse(RelObject object) {
+
+    public StreamedListObjectsResponse {
+        Preconditions.parameterNonNull(object, "object");
+    }
+}

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/WriteAssertionsRequest.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/WriteAssertionsRequest.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.quarkiverse.openfga.client.model.Assertion;
@@ -25,6 +26,14 @@ public final class WriteAssertionsRequest {
         private Builder() {
         }
 
+        /**
+         * Sets the authorization model ID used by the compatibility API overload as a path parameter.
+         *
+         * @param authorizationModelId authorization model ID
+         * @return this builder
+         * @deprecated pass the authorization model ID separately to the API operation
+         */
+        @Deprecated(since = "3.15", forRemoval = true)
         public Builder authorizationModelId(@Nullable String authorizationModelId) {
             this.authorizationModelId = authorizationModelId;
             return this;
@@ -37,7 +46,7 @@ public final class WriteAssertionsRequest {
 
         public WriteAssertionsRequest build() {
             return new WriteAssertionsRequest(
-                    Preconditions.parameterNonBlank(authorizationModelId, "authorizationModelId"),
+                    authorizationModelId,
                     Preconditions.parameterNonNull(assertions, "assertions"));
         }
     }
@@ -46,16 +55,26 @@ public final class WriteAssertionsRequest {
         return new Builder();
     }
 
+    @Nullable
     private final String authorizationModelId;
     private final List<Assertion> assertions;
 
     @JsonCreator(mode = PROPERTIES)
-    WriteAssertionsRequest(@JsonProperty("authorization_model_id") String authorizationModelId, List<Assertion> assertions) {
+    WriteAssertionsRequest(@JsonProperty("authorization_model_id") @Nullable String authorizationModelId,
+            List<Assertion> assertions) {
         this.authorizationModelId = authorizationModelId;
         this.assertions = assertions;
     }
 
-    @JsonProperty("authorization_model_id")
+    /**
+     * Returns the authorization model ID used by the compatibility API overload.
+     *
+     * @return authorization model ID
+     * @deprecated the value is a path parameter and is not part of the request body
+     */
+    @JsonIgnore
+    @Deprecated(since = "3.15", forRemoval = true)
+    @Nullable
     public String getAuthorizationModelId() {
         return authorizationModelId;
     }

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/dto/WriteRequest.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/dto/WriteRequest.java
@@ -11,10 +11,14 @@ import javax.annotation.Nullable;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import io.quarkiverse.openfga.client.model.RelTupleKeyed;
+import io.quarkiverse.openfga.client.model.WriteConflictBehavior;
+import io.quarkiverse.openfga.client.model.json.WriteRequestSerializer;
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
 
+@JsonSerialize(using = WriteRequestSerializer.class)
 public final class WriteRequest {
 
     public record Writes(
@@ -50,6 +54,8 @@ public final class WriteRequest {
         private @Nullable String authorizationModelId;
         private @Nullable Writes writes;
         private @Nullable Deletes deletes;
+        private @Nullable WriteConflictBehavior onDuplicate;
+        private @Nullable WriteConflictBehavior onMissing;
 
         private Builder() {
         }
@@ -69,8 +75,30 @@ public final class WriteRequest {
             return this;
         }
 
+        /**
+         * Sets the behavior when a written tuple already exists.
+         *
+         * @param onDuplicate duplicate handling behavior
+         * @return this builder
+         */
+        public Builder onDuplicate(@Nullable WriteConflictBehavior onDuplicate) {
+            this.onDuplicate = onDuplicate;
+            return this;
+        }
+
+        /**
+         * Sets the behavior when a deleted tuple does not exist.
+         *
+         * @param onMissing missing tuple handling behavior
+         * @return this builder
+         */
+        public Builder onMissing(@Nullable WriteConflictBehavior onMissing) {
+            this.onMissing = onMissing;
+            return this;
+        }
+
         public WriteRequest build() {
-            return new WriteRequest(writes, deletes, authorizationModelId);
+            return new WriteRequest(writes, deletes, authorizationModelId, onDuplicate, onMissing);
         }
     }
 
@@ -84,13 +112,21 @@ public final class WriteRequest {
     private final Deletes deletes;
     @Nullable
     private final String authorizationModelId;
+    @Nullable
+    private final WriteConflictBehavior onDuplicate;
+    @Nullable
+    private final WriteConflictBehavior onMissing;
 
     @JsonCreator(mode = PROPERTIES)
     WriteRequest(@Nullable Writes writes, @Nullable Deletes deletes,
-            @JsonProperty("authorization_model_id") @Nullable String authorizationModelId) {
+            @JsonProperty("authorization_model_id") @Nullable String authorizationModelId,
+            @JsonProperty("on_duplicate") @Nullable WriteConflictBehavior onDuplicate,
+            @JsonProperty("on_missing") @Nullable WriteConflictBehavior onMissing) {
         this.writes = writes;
         this.deletes = deletes;
         this.authorizationModelId = authorizationModelId;
+        this.onDuplicate = onDuplicate;
+        this.onMissing = onMissing;
     }
 
     @Nullable
@@ -109,18 +145,40 @@ public final class WriteRequest {
         return authorizationModelId;
     }
 
+    /**
+     * Returns the duplicate handling behavior.
+     *
+     * @return duplicate handling behavior, or {@code null} for the server default
+     */
+    @Nullable
+    public WriteConflictBehavior getOnDuplicate() {
+        return onDuplicate;
+    }
+
+    /**
+     * Returns the missing tuple handling behavior.
+     *
+     * @return missing tuple handling behavior, or {@code null} for the server default
+     */
+    @Nullable
+    public WriteConflictBehavior getOnMissing() {
+        return onMissing;
+    }
+
     @Override
     public boolean equals(@Nullable Object obj) {
         if (!(obj instanceof WriteRequest that))
             return false;
         return Objects.equals(this.writes, that.writes) &&
                 Objects.equals(this.deletes, that.deletes) &&
-                Objects.equals(this.authorizationModelId, that.authorizationModelId);
+                Objects.equals(this.authorizationModelId, that.authorizationModelId) &&
+                Objects.equals(this.onDuplicate, that.onDuplicate) &&
+                Objects.equals(this.onMissing, that.onMissing);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(writes, deletes, authorizationModelId);
+        return Objects.hash(writes, deletes, authorizationModelId, onDuplicate, onMissing);
     }
 
     @Override
@@ -128,7 +186,9 @@ public final class WriteRequest {
         return "WriteBody[" +
                 "writes=" + writes + ", " +
                 "deletes=" + deletes + ", " +
-                "authorizationModelId=" + authorizationModelId + ']';
+                "authorizationModelId=" + authorizationModelId + ", " +
+                "onDuplicate=" + onDuplicate + ", " +
+                "onMissing=" + onMissing + ']';
     }
 
 }

--- a/model/src/main/java/io/quarkiverse/openfga/client/model/json/WriteRequestSerializer.java
+++ b/model/src/main/java/io/quarkiverse/openfga/client/model/json/WriteRequestSerializer.java
@@ -1,0 +1,48 @@
+package io.quarkiverse.openfga.client.model.json;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import io.quarkiverse.openfga.client.model.dto.WriteRequest;
+
+/**
+ * Serializes a write request while preserving its compatibility-oriented Java shape.
+ */
+public final class WriteRequestSerializer extends StdSerializer<WriteRequest> {
+
+    /** Creates a write request serializer. */
+    public WriteRequestSerializer() {
+        super(WriteRequest.class);
+    }
+
+    @Override
+    public void serialize(WriteRequest request, JsonGenerator generator, SerializerProvider provider) throws IOException {
+        generator.writeStartObject();
+        if (request.getWrites() != null) {
+            generator.writeObjectFieldStart("writes");
+            generator.writeFieldName("tuple_keys");
+            provider.defaultSerializeValue(request.getWrites().tupleKeys(), generator);
+            if (request.getOnDuplicate() != null) {
+                generator.writeObjectField("on_duplicate", request.getOnDuplicate());
+            }
+            generator.writeEndObject();
+        }
+        if (request.getDeletes() != null) {
+            generator.writeObjectFieldStart("deletes");
+            generator.writeFieldName("tuple_keys");
+            provider.defaultSerializeValue(
+                    request.getDeletes().tupleKeys().stream().map(tupleKey -> tupleKey.key()).toList(), generator);
+            if (request.getOnMissing() != null) {
+                generator.writeObjectField("on_missing", request.getOnMissing());
+            }
+            generator.writeEndObject();
+        }
+        if (request.getAuthorizationModelId() != null) {
+            generator.writeStringField("authorization_model_id", request.getAuthorizationModelId());
+        }
+        generator.writeEndObject();
+    }
+}

--- a/model/src/test/java/io/quarkiverse/openfga/client/model/OpenFGAWireContractTest.java
+++ b/model/src/test/java/io/quarkiverse/openfga/client/model/OpenFGAWireContractTest.java
@@ -1,0 +1,126 @@
+package io.quarkiverse.openfga.client.model;
+
+import static io.quarkiverse.openfga.client.model.utils.ModelMapper.mapper;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.quarkiverse.openfga.client.model.dto.BatchCheckRequest;
+import io.quarkiverse.openfga.client.model.dto.ExpandRequest;
+import io.quarkiverse.openfga.client.model.dto.ReadRequest;
+import io.quarkiverse.openfga.client.model.dto.StreamedListObjectsResponse;
+import io.quarkiverse.openfga.client.model.dto.WriteAssertionsRequest;
+import io.quarkiverse.openfga.client.model.dto.WriteRequest;
+
+/**
+ * Verifies request shapes against openfga/api commit 6981fff8d33bee21dd9a2001608e6d6c5f553977.
+ */
+@SuppressWarnings("removal")
+public class OpenFGAWireContractTest {
+
+    @Test
+    void readOmitsCompatibilityAuthorizationModelIdAndIncludesConsistency() throws Exception {
+        var request = ReadRequest.builder()
+                .authorizationModelId("01MODEL")
+                .consistency(ConsistencyPreference.HIGHER_CONSISTENCY)
+                .build();
+
+        var json = json(request);
+
+        assertThat(json.has("authorization_model_id")).isFalse();
+        assertThat(json.path("consistency").textValue()).isEqualTo("HIGHER_CONSISTENCY");
+    }
+
+    @Test
+    void expandOmitsCompatibilityContext() throws Exception {
+        var request = ExpandRequest.builder()
+                .tupleKey(RelPartialTupleKey.builder()
+                        .object(RelObject.of("document", "roadmap"))
+                        .relation("viewer")
+                        .build())
+                .context(Map.of("region", "eu"))
+                .build();
+
+        var json = json(request);
+
+        assertThat(json.has("context")).isFalse();
+    }
+
+    @Test
+    void assertionsOmitPathParameterAndPreserveOnlySupportedConditions() throws Exception {
+        var conditionalTuple = conditionalTuple();
+        var request = WriteAssertionsRequest.builder()
+                .authorizationModelId("01MODEL")
+                .assertions(List.of(Assertion.of(conditionalTuple, true, List.of(conditionalTuple),
+                        Map.of("region", "eu"))))
+                .build();
+
+        var json = json(request);
+        var assertion = json.path("assertions").get(0);
+
+        assertThat(json.has("authorization_model_id")).isFalse();
+        assertThat(assertion.path("tuple_key").has("condition")).isFalse();
+        assertThat(assertion.path("contextual_tuples").get(0).path("condition").path("name").textValue())
+                .isEqualTo("in_region");
+        assertThat(assertion.path("context").path("region").textValue()).isEqualTo("eu");
+    }
+
+    @Test
+    void batchCheckOmitsConditionsFromCheckTupleKeys() throws Exception {
+        var request = BatchCheckRequest.builder()
+                .checks(List.of(Check.builder()
+                        .tupleKey(conditionalTuple())
+                        .correlationId("check-1")
+                        .build()))
+                .build();
+
+        var json = json(request);
+
+        assertThat(json.path("checks").get(0).path("tuple_key").has("condition")).isFalse();
+    }
+
+    @Test
+    void writeNestsConflictBehaviorAndPreservesOnlyWriteConditions() throws Exception {
+        var conditionalTuple = conditionalTuple();
+        var request = WriteRequest.builder()
+                .authorizationModelId("01MODEL")
+                .writes(WriteRequest.Writes.of(List.of(conditionalTuple)))
+                .deletes(WriteRequest.Deletes.of(List.of(conditionalTuple)))
+                .onDuplicate(WriteConflictBehavior.IGNORE)
+                .onMissing(WriteConflictBehavior.IGNORE)
+                .build();
+
+        var json = json(request);
+
+        assertThat(json.path("writes").path("on_duplicate").textValue()).isEqualTo("ignore");
+        assertThat(json.path("writes").path("tuple_keys").get(0).path("condition").path("name").textValue())
+                .isEqualTo("in_region");
+        assertThat(json.path("deletes").path("on_missing").textValue()).isEqualTo("ignore");
+        assertThat(json.path("deletes").path("tuple_keys").get(0).has("condition")).isFalse();
+    }
+
+    @Test
+    void streamedListObjectsResponseDecodesObject() throws Exception {
+        var response = mapper.readValue("{\"object\":\"document:roadmap\"}", StreamedListObjectsResponse.class);
+
+        assertThat(response.object()).isEqualTo(RelObject.of("document", "roadmap"));
+    }
+
+    private static RelTupleDefinition conditionalTuple() {
+        return RelTupleDefinition.builder()
+                .object(RelObject.of("document", "roadmap"))
+                .relation("viewer")
+                .user(RelUser.of("user", "anne"))
+                .condition(RelCondition.of("in_region", Map.of("region", "eu")))
+                .build();
+    }
+
+    private static JsonNode json(Object value) throws Exception {
+        return mapper.readTree(mapper.writeValueAsString(value));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <quarkus.version>3.38.0</quarkus.version>
     <jandex-maven-plugin.version>3.6.0</jandex-maven-plugin.version>
     <assertj.version>3.27.7</assertj.version>
+    <japicmp.version>0.24.2</japicmp.version>
     <argLine />
   </properties>
   <dependencyManagement>
@@ -78,6 +79,44 @@
     </plugins>
   </build>
   <profiles>
+    <profile>
+      <id>binary-compatibility</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.siom79.japicmp</groupId>
+            <artifactId>japicmp-maven-plugin</artifactId>
+            <version>${japicmp.version}</version>
+            <executions>
+              <execution>
+                <phase>verify</phase>
+                <goals>
+                  <goal>cmp</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <oldVersion>
+                <dependency>
+                  <groupId>${project.groupId}</groupId>
+                  <artifactId>${project.artifactId}</artifactId>
+                  <version>3.14.0</version>
+                </dependency>
+              </oldVersion>
+              <parameter>
+                <onlyModified>true</onlyModified>
+                <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+                <ignoreMissingClasses>true</ignoreMissingClasses>
+                <skipPomModules>true</skipPomModules>
+              </parameter>
+              <skipHtmlReport>true</skipHtmlReport>
+              <skipMarkdownReport>true</skipMarkdownReport>
+              <skipXmlReport>true</skipXmlReport>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>docs</id>
       <activation>

--- a/runtime/src/main/java/io/quarkiverse/openfga/client/AssertionsClient.java
+++ b/runtime/src/main/java/io/quarkiverse/openfga/client/AssertionsClient.java
@@ -26,10 +26,9 @@ public class AssertionsClient {
     public Uni<Void> update(List<Assertion> assertions) {
         return config.flatMap(config -> {
             var request = WriteAssertionsRequest.builder()
-                    .authorizationModelId(config.getAuthorizationModelId())
                     .assertions(assertions)
                     .build();
-            return api.writeAssertions(config.getStoreId(), request);
+            return api.writeAssertions(config.getStoreId(), config.getAuthorizationModelId(), request);
         });
     }
 

--- a/runtime/src/main/java/io/quarkiverse/openfga/client/AuthorizationModelClient.java
+++ b/runtime/src/main/java/io/quarkiverse/openfga/client/AuthorizationModelClient.java
@@ -15,6 +15,7 @@ import io.quarkiverse.openfga.client.model.dto.*;
 import io.quarkiverse.openfga.client.model.utils.Preconditions;
 import io.quarkiverse.openfga.client.utils.PaginatedList;
 import io.quarkiverse.openfga.client.utils.Pagination;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
 public class AuthorizationModelClient {
@@ -79,18 +80,43 @@ public class AuthorizationModelClient {
     }
 
     public Uni<Boolean> check(RelTupleKeyed relKey, CheckOptions options) {
+        return checkResponse(relKey, options, null).map(CheckResponse::allowed);
+    }
+
+    /**
+     * Checks a relationship and requests resolution details from OpenFGA.
+     *
+     * @param relKey relationship to check
+     * @return detailed check response
+     */
+    public Uni<CheckResponse> checkDetailed(RelTupleKeyed relKey) {
+        return checkDetailed(relKey, CheckOptions.DEFAULT);
+    }
+
+    /**
+     * Checks a relationship and requests resolution details from OpenFGA.
+     *
+     * @param relKey relationship to check
+     * @param options check options
+     * @return detailed check response
+     */
+    public Uni<CheckResponse> checkDetailed(RelTupleKeyed relKey, CheckOptions options) {
+        return checkResponse(relKey, options, true);
+    }
+
+    private Uni<CheckResponse> checkResponse(RelTupleKeyed relKey, CheckOptions options, @Nullable Boolean trace) {
         return config
                 .flatMap(config -> {
                     var request = CheckRequest.builder()
                             .authorizationModelId(config.getAuthorizationModelId())
                             .tupleKey(relKey)
                             .contextualTuples(options.contextualTuples.map(RelTupleKeys::of).orElse(null))
+                            .trace(trace)
                             .context(options.context.orElse(null))
                             .consistency(options.consistency.orElse(null))
                             .build();
                     return api.check(config.getStoreId(), request);
-                })
-                .map(CheckResponse::allowed);
+                });
     }
 
     public record BatchCheckOptions(Optional<ConsistencyPreference> consistency) {
@@ -142,6 +168,14 @@ public class AuthorizationModelClient {
             return withContextualTuples(List.of(contextualTuples));
         }
 
+        /**
+         * Retains an expand context for source compatibility. OpenFGA does not accept it on the wire.
+         *
+         * @param context ignored context
+         * @return expand options
+         * @deprecated OpenFGA Expand does not accept evaluation context
+         */
+        @Deprecated(since = "3.15", forRemoval = true)
         public static ExpandOptions withContext(@Nullable Map<String, Object> context) {
             return new ExpandOptions(Optional.empty(), Optional.ofNullable(context), Optional.empty());
         }
@@ -158,6 +192,14 @@ public class AuthorizationModelClient {
             return contextualTuples(List.of(contextualTuples));
         }
 
+        /**
+         * Retains an expand context for source compatibility. OpenFGA does not accept it on the wire.
+         *
+         * @param context ignored context
+         * @return updated expand options
+         * @deprecated OpenFGA Expand does not accept evaluation context
+         */
+        @Deprecated(since = "3.15", forRemoval = true)
         public ExpandOptions context(@Nullable Map<String, Object> context) {
             return new ExpandOptions(contextualTuples, Optional.ofNullable(context), consistency);
         }
@@ -177,7 +219,6 @@ public class AuthorizationModelClient {
                     .authorizationModelId(config.getAuthorizationModelId())
                     .tupleKey(tupleKey)
                     .contextualTuples(options.contextualTuples.map(RelTupleKeys::of).orElse(null))
-                    .context(options.context.orElse(null))
                     .consistency(options.consistency.orElse(null))
                     .build();
             return api.expand(config.getStoreId(), request);
@@ -285,22 +326,51 @@ public class AuthorizationModelClient {
     }
 
     public Uni<Collection<RelObject>> listObjects(ListObjectsFilter filter, ListOptions options) {
+        return config.flatMap(config -> {
+            var request = listObjectsRequest(config, filter, options);
+            return api.listObjects(config.getStoreId(), request);
+        }).map(ListObjectsResponse::objects);
+    }
+
+    /**
+     * Streams objects matching the supplied filter.
+     *
+     * @param filter list objects filter
+     * @return matching objects as OpenFGA produces them
+     */
+    public Multi<RelObject> streamObjects(ListObjectsFilter filter) {
+        return streamObjects(filter, ListOptions.DEFAULT);
+    }
+
+    /**
+     * Streams objects matching the supplied filter and options.
+     *
+     * @param filter list objects filter
+     * @param options list objects options
+     * @return matching objects as OpenFGA produces them
+     */
+    public Multi<RelObject> streamObjects(ListObjectsFilter filter, ListOptions options) {
+        return config.toMulti()
+                .onItem().transformToMultiAndConcatenate(config -> api.streamedListObjects(config.getStoreId(),
+                        listObjectsRequest(config, filter, options)))
+                .map(StreamedListObjectsResponse::object);
+    }
+
+    private static ListObjectsRequest listObjectsRequest(ClientConfig config, ListObjectsFilter filter,
+            ListOptions options) {
         Preconditions.parameterNonNull(filter, "filter");
         var type = Preconditions.parameterNonNull(filter.type, "filter.type");
         var relation = Preconditions.parameterNonNull(filter.relation, "filter.relation");
         var user = Preconditions.parameterNonNull(filter.user, "filter.user");
-        return config.flatMap(config -> {
-            var request = ListObjectsRequest.builder()
-                    .authorizationModelId(config.getAuthorizationModelId())
-                    .type(type)
-                    .relation(relation)
-                    .user(user.asUser())
-                    .contextualTuples(options.contextualTuples.orElse(null))
-                    .context(options.context.orElse(null))
-                    .consistency(options.consistency.orElse(null))
-                    .build();
-            return api.listObjects(config.getStoreId(), request);
-        }).map(ListObjectsResponse::objects);
+        return ListObjectsRequest.builder()
+                .authorizationModelId(config.getAuthorizationModelId())
+                .type(type)
+                .relation(relation)
+                .user(user.asUser())
+                .contextualTuples(options.contextualTuples.orElse(null))
+                .context(options.context.orElse(null))
+                .consistency(options.consistency.orElse(null))
+                .build();
     }
 
     /**
@@ -400,6 +470,15 @@ public class AuthorizationModelClient {
         }).map(ListUsersResponse::asRel);
     }
 
+    /**
+     * Compatibility filter for the store-scoped Read API.
+     *
+     * @param typeOrObject optional object type or concrete object
+     * @param relation optional relation
+     * @param user optional user
+     * @deprecated use {@link StoreClient.ReadTuplesFilter}
+     */
+    @Deprecated(since = "3.15", forRemoval = true)
     public record ReadFilter(Optional<RelTyped> typeOrObject, Optional<String> relation, Optional<RelEntity> user) {
 
         public static final ReadFilter ALL = new ReadFilter();
@@ -465,22 +544,53 @@ public class AuthorizationModelClient {
         }
     }
 
+    /**
+     * Reads tuples from the store containing this model.
+     *
+     * @return a page of tuples
+     * @deprecated use {@link StoreClient#readTuples()}
+     */
+    @Deprecated(since = "3.15", forRemoval = true)
     public Uni<PaginatedList<RelTuple>> read() {
         return read(ReadFilter.ALL, Pagination.DEFAULT);
     }
 
+    /**
+     * Reads filtered tuples from the store containing this model.
+     *
+     * @param filter tuple filter
+     * @return a page of tuples
+     * @deprecated use {@link StoreClient#readTuples(StoreClient.ReadTuplesFilter)}
+     */
+    @Deprecated(since = "3.15", forRemoval = true)
     public Uni<PaginatedList<RelTuple>> read(ReadFilter filter) {
         return read(filter, Pagination.DEFAULT);
     }
 
+    /**
+     * Reads tuples from the store containing this model.
+     *
+     * @param options pagination request
+     * @return a page of tuples
+     * @deprecated use {@link StoreClient#readTuples(Pagination)}
+     */
+    @Deprecated(since = "3.15", forRemoval = true)
     public Uni<PaginatedList<RelTuple>> read(Pagination options) {
         return read(ReadFilter.ALL, options);
     }
 
+    /**
+     * Reads filtered tuples from the store containing this model.
+     *
+     * @param filter tuple filter
+     * @param options pagination request
+     * @return a page of tuples
+     * @deprecated use {@link StoreClient#readTuples(StoreClient.ReadTuplesFilter, Pagination)}
+     */
+    @Deprecated(since = "3.15", forRemoval = true)
     public Uni<PaginatedList<RelTuple>> read(ReadFilter filter, Pagination options) {
         return config.flatMap(config -> {
             var request = ReadRequest.builder()
-                    .authorizationModelId(config.getAuthorizationModelId())
                     .tupleKey(ReadRequest.TupleKeyFilter.builder()
                             .typeOrObject(filter.typeOrObject.orElse(null))
                             .relation(filter.relation.orElse(null))
@@ -493,16 +603,99 @@ public class AuthorizationModelClient {
         }).map(res -> new PaginatedList<>(res.tuples(), res.continuationToken()));
     }
 
+    /**
+     * Reads all tuples from the store containing this model.
+     *
+     * @return all tuples
+     * @deprecated use {@link StoreClient#readAllTuples()}
+     */
+    @Deprecated(since = "3.15", forRemoval = true)
     public Uni<List<RelTuple>> readAll() {
         return readAll(ReadFilter.ALL, Pagination.MAX.pageSize());
     }
 
+    /**
+     * Reads all filtered tuples from the store containing this model.
+     *
+     * @param filter tuple filter
+     * @return all matching tuples
+     * @deprecated use {@link StoreClient#readAllTuples(StoreClient.ReadTuplesFilter)}
+     */
+    @Deprecated(since = "3.15", forRemoval = true)
     public Uni<List<RelTuple>> readAll(ReadFilter filter) {
         return readAll(filter, Pagination.MAX.pageSize());
     }
 
+    /**
+     * Reads all filtered tuples from the store containing this model.
+     *
+     * @param filter tuple filter
+     * @param pageSize page size
+     * @return all matching tuples
+     * @deprecated use {@link StoreClient#readAllTuples(StoreClient.ReadTuplesFilter, Integer,
+     *             StoreClient.ReadTuplesOptions)}
+     */
+    @Deprecated(since = "3.15", forRemoval = true)
     public Uni<List<RelTuple>> readAll(ReadFilter filter, @Nullable Integer pageSize) {
         return collectAllPages(pageSize, (pagination) -> this.read(filter, pagination));
+    }
+
+    /**
+     * Options controlling how OpenFGA handles tuple write conflicts.
+     *
+     * @param onDuplicate behavior when a written tuple already exists
+     * @param onMissing behavior when a deleted tuple does not exist
+     */
+    public record WriteOptions(Optional<WriteConflictBehavior> onDuplicate,
+            Optional<WriteConflictBehavior> onMissing) {
+
+        /** Uses OpenFGA's default conflict behavior. */
+        public static final WriteOptions DEFAULT = new WriteOptions();
+
+        /** Creates options using OpenFGA's default conflict behavior. */
+        public WriteOptions() {
+            this(Optional.empty(), Optional.empty());
+        }
+
+        /**
+         * Creates options for duplicate tuple writes.
+         *
+         * @param onDuplicate duplicate handling behavior
+         * @return write options
+         */
+        public static WriteOptions withOnDuplicate(@Nullable WriteConflictBehavior onDuplicate) {
+            return new WriteOptions(Optional.ofNullable(onDuplicate), Optional.empty());
+        }
+
+        /**
+         * Creates options for missing tuple deletes.
+         *
+         * @param onMissing missing tuple handling behavior
+         * @return write options
+         */
+        public static WriteOptions withOnMissing(@Nullable WriteConflictBehavior onMissing) {
+            return new WriteOptions(Optional.empty(), Optional.ofNullable(onMissing));
+        }
+
+        /**
+         * Sets duplicate tuple handling.
+         *
+         * @param onDuplicate duplicate handling behavior
+         * @return updated write options
+         */
+        public WriteOptions onDuplicate(@Nullable WriteConflictBehavior onDuplicate) {
+            return new WriteOptions(Optional.ofNullable(onDuplicate), onMissing);
+        }
+
+        /**
+         * Sets missing tuple handling.
+         *
+         * @param onMissing missing tuple handling behavior
+         * @return updated write options
+         */
+        public WriteOptions onMissing(@Nullable WriteConflictBehavior onMissing) {
+            return new WriteOptions(onDuplicate, Optional.ofNullable(onMissing));
+        }
     }
 
     public Uni<Map<String, Object>> write(RelTupleDefinition... tupleDefs) {
@@ -513,6 +706,17 @@ public class AuthorizationModelClient {
         return write(writes, List.of());
     }
 
+    /**
+     * Writes tuples using the supplied conflict options.
+     *
+     * @param writes tuples to write
+     * @param options write options
+     * @return OpenFGA write response values
+     */
+    public Uni<Map<String, Object>> write(Collection<RelTupleDefinition> writes, WriteOptions options) {
+        return write(writes, List.of(), options);
+    }
+
     public Uni<Map<String, Object>> delete(RelTupleDefinition... tupleDefs) {
         return delete(List.of(tupleDefs));
     }
@@ -521,11 +725,37 @@ public class AuthorizationModelClient {
         return write(List.of(), deletes);
     }
 
+    /**
+     * Deletes tuples using the supplied conflict options.
+     *
+     * @param deletes tuples to delete
+     * @param options write options
+     * @return OpenFGA write response values
+     */
+    public Uni<Map<String, Object>> delete(Collection<RelTupleDefinition> deletes, WriteOptions options) {
+        return write(List.of(), deletes, options);
+    }
+
     public Uni<Map<String, Object>> write(@Nullable Collection<RelTupleDefinition> writes,
             @Nullable Collection<? extends RelTupleKeyed> deletes) {
+        return write(writes, deletes, WriteOptions.DEFAULT);
+    }
+
+    /**
+     * Writes and deletes tuples using the supplied conflict options.
+     *
+     * @param writes tuples to write
+     * @param deletes tuples to delete
+     * @param options write options
+     * @return OpenFGA write response values
+     */
+    public Uni<Map<String, Object>> write(@Nullable Collection<RelTupleDefinition> writes,
+            @Nullable Collection<? extends RelTupleKeyed> deletes, WriteOptions options) {
         return config.flatMap(config -> {
             var request = WriteRequest.builder()
-                    .authorizationModelId(config.getAuthorizationModelId());
+                    .authorizationModelId(config.getAuthorizationModelId())
+                    .onDuplicate(options.onDuplicate.orElse(null))
+                    .onMissing(options.onMissing.orElse(null));
             if (writes != null && !writes.isEmpty()) {
                 request.writes(new WriteRequest.Writes(writes));
             }

--- a/runtime/src/main/java/io/quarkiverse/openfga/client/StoreClient.java
+++ b/runtime/src/main/java/io/quarkiverse/openfga/client/StoreClient.java
@@ -9,9 +9,14 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 
 import io.quarkiverse.openfga.client.api.API;
+import io.quarkiverse.openfga.client.model.ConsistencyPreference;
+import io.quarkiverse.openfga.client.model.RelEntity;
+import io.quarkiverse.openfga.client.model.RelObject;
 import io.quarkiverse.openfga.client.model.RelObjectType;
 import io.quarkiverse.openfga.client.model.RelTuple;
 import io.quarkiverse.openfga.client.model.RelTupleChange;
+import io.quarkiverse.openfga.client.model.RelTyped;
+import io.quarkiverse.openfga.client.model.RelUser;
 import io.quarkiverse.openfga.client.model.Store;
 import io.quarkiverse.openfga.client.model.dto.GetStoreResponse;
 import io.quarkiverse.openfga.client.model.dto.ReadChangesRequest;
@@ -95,25 +100,293 @@ public class StoreClient {
         return collectAllPages(pageSize, pagination -> readChanges(filter, pagination));
     }
 
+    /**
+     * Filters tuples read from this store.
+     *
+     * @param typeOrObject optional object type or concrete object
+     * @param relation optional relation
+     * @param user optional user
+     */
+    public record ReadTuplesFilter(Optional<RelTyped> typeOrObject, Optional<String> relation,
+            Optional<RelEntity> user) {
+
+        /** Matches every tuple in the store. */
+        public static final ReadTuplesFilter ALL = new ReadTuplesFilter();
+
+        /**
+         * Creates a filter matching an object type.
+         *
+         * @param type object type
+         * @return tuple filter
+         */
+        public static ReadTuplesFilter byObjectType(@Nullable RelTyped type) {
+            return ALL.objectType(type);
+        }
+
+        /**
+         * Creates a filter matching an object type.
+         *
+         * @param type object type
+         * @return tuple filter
+         */
+        public static ReadTuplesFilter byObjectType(@Nullable String type) {
+            return ALL.objectType(type);
+        }
+
+        /**
+         * Creates a filter matching an object.
+         *
+         * @param object object
+         * @return tuple filter
+         */
+        public static ReadTuplesFilter byObject(@Nullable RelEntity object) {
+            return ALL.object(object);
+        }
+
+        /**
+         * Creates a filter matching an object.
+         *
+         * @param object object
+         * @return tuple filter
+         */
+        public static ReadTuplesFilter byObject(@Nullable String object) {
+            return ALL.object(object);
+        }
+
+        /**
+         * Creates a filter matching a relation.
+         *
+         * @param relation relation
+         * @return tuple filter
+         */
+        public static ReadTuplesFilter byRelation(@Nullable String relation) {
+            return ALL.relation(relation);
+        }
+
+        /**
+         * Creates a filter matching a user.
+         *
+         * @param user user
+         * @return tuple filter
+         */
+        public static ReadTuplesFilter byUser(@Nullable RelEntity user) {
+            return ALL.user(user);
+        }
+
+        /**
+         * Creates a filter matching a user.
+         *
+         * @param user user
+         * @return tuple filter
+         */
+        public static ReadTuplesFilter byUser(@Nullable String user) {
+            return ALL.user(user);
+        }
+
+        /** Creates a filter matching every tuple. */
+        public ReadTuplesFilter() {
+            this(Optional.empty(), Optional.empty(), Optional.empty());
+        }
+
+        /**
+         * Adds an object type constraint.
+         *
+         * @param type object type
+         * @return updated tuple filter
+         */
+        public ReadTuplesFilter objectType(@Nullable RelTyped type) {
+            return new ReadTuplesFilter(Optional.ofNullable(type), relation, user);
+        }
+
+        /**
+         * Adds an object type constraint.
+         *
+         * @param type object type
+         * @return updated tuple filter
+         */
+        public ReadTuplesFilter objectType(@Nullable String type) {
+            return new ReadTuplesFilter(Optional.ofNullable(type).map(RelObjectType::of), relation, user);
+        }
+
+        /**
+         * Adds an object constraint.
+         *
+         * @param object object
+         * @return updated tuple filter
+         */
+        public ReadTuplesFilter object(@Nullable RelEntity object) {
+            return new ReadTuplesFilter(Optional.ofNullable(object), relation, user);
+        }
+
+        /**
+         * Adds an object constraint.
+         *
+         * @param object object
+         * @return updated tuple filter
+         */
+        public ReadTuplesFilter object(@Nullable String object) {
+            return new ReadTuplesFilter(Optional.ofNullable(object).map(RelObject::valueOf), relation, user);
+        }
+
+        /**
+         * Adds a relation constraint.
+         *
+         * @param relation relation
+         * @return updated tuple filter
+         */
+        public ReadTuplesFilter relation(@Nullable String relation) {
+            return new ReadTuplesFilter(typeOrObject, Optional.ofNullable(relation), user);
+        }
+
+        /**
+         * Adds a user constraint.
+         *
+         * @param user user
+         * @return updated tuple filter
+         */
+        public ReadTuplesFilter user(@Nullable RelEntity user) {
+            return new ReadTuplesFilter(typeOrObject, relation, Optional.ofNullable(user));
+        }
+
+        /**
+         * Adds a user constraint.
+         *
+         * @param user user
+         * @return updated tuple filter
+         */
+        public ReadTuplesFilter user(@Nullable String user) {
+            return new ReadTuplesFilter(typeOrObject, relation, Optional.ofNullable(user).map(RelUser::valueOf));
+        }
+    }
+
+    /**
+     * Options controlling tuple reads.
+     *
+     * @param consistency optional consistency preference
+     */
+    public record ReadTuplesOptions(Optional<ConsistencyPreference> consistency) {
+
+        /** Uses the OpenFGA server's default consistency. */
+        public static final ReadTuplesOptions DEFAULT = new ReadTuplesOptions();
+
+        /** Creates options using the OpenFGA server's default consistency. */
+        public ReadTuplesOptions() {
+            this(Optional.empty());
+        }
+
+        /**
+         * Creates options with a consistency preference.
+         *
+         * @param consistency consistency preference
+         * @return read options
+         */
+        public static ReadTuplesOptions withConsistency(@Nullable ConsistencyPreference consistency) {
+            return new ReadTuplesOptions(Optional.ofNullable(consistency));
+        }
+
+        /**
+         * Sets the consistency preference.
+         *
+         * @param consistency consistency preference
+         * @return updated read options
+         */
+        public ReadTuplesOptions consistency(@Nullable ConsistencyPreference consistency) {
+            return new ReadTuplesOptions(Optional.ofNullable(consistency));
+        }
+    }
+
     public Uni<PaginatedList<RelTuple>> readTuples() {
-        return readTuples(Pagination.DEFAULT);
+        return readTuples(ReadTuplesFilter.ALL, Pagination.DEFAULT, ReadTuplesOptions.DEFAULT);
     }
 
     public Uni<PaginatedList<RelTuple>> readTuples(Pagination pagination) {
+        return readTuples(ReadTuplesFilter.ALL, pagination, ReadTuplesOptions.DEFAULT);
+    }
+
+    /**
+     * Reads tuples matching a filter.
+     *
+     * @param filter tuple filter
+     * @return a page of tuples
+     */
+    public Uni<PaginatedList<RelTuple>> readTuples(ReadTuplesFilter filter) {
+        return readTuples(filter, Pagination.DEFAULT, ReadTuplesOptions.DEFAULT);
+    }
+
+    /**
+     * Reads tuples using the supplied options.
+     *
+     * @param options read options
+     * @return a page of tuples
+     */
+    public Uni<PaginatedList<RelTuple>> readTuples(ReadTuplesOptions options) {
+        return readTuples(ReadTuplesFilter.ALL, Pagination.DEFAULT, options);
+    }
+
+    /**
+     * Reads tuples matching a filter and pagination request.
+     *
+     * @param filter tuple filter
+     * @param pagination pagination request
+     * @return a page of tuples
+     */
+    public Uni<PaginatedList<RelTuple>> readTuples(ReadTuplesFilter filter, Pagination pagination) {
+        return readTuples(filter, pagination, ReadTuplesOptions.DEFAULT);
+    }
+
+    /**
+     * Reads tuples matching a filter, pagination request, and consistency preference.
+     *
+     * @param filter tuple filter
+     * @param pagination pagination request
+     * @param options read options
+     * @return a page of tuples
+     */
+    public Uni<PaginatedList<RelTuple>> readTuples(ReadTuplesFilter filter, Pagination pagination,
+            ReadTuplesOptions options) {
         var request = ReadRequest.builder()
+                .tupleKey(ReadRequest.TupleKeyFilter.builder()
+                        .typeOrObject(filter.typeOrObject.orElse(null))
+                        .relation(filter.relation.orElse(null))
+                        .user(filter.user.map(RelEntity::asUser).orElse(null))
+                        .build())
                 .pageSize(pagination.pageSize())
                 .continuationToken(pagination.continuationToken().orElse(null))
+                .consistency(options.consistency.orElse(null))
                 .build();
         return storeId.flatMap(storeId -> api.read(storeId, request))
                 .map(res -> new PaginatedList<>(res.tuples(), res.continuationToken()));
     }
 
     public Uni<List<RelTuple>> readAllTuples() {
-        return readAllTuples(null);
+        return readAllTuples((Integer) null);
     }
 
     public Uni<List<RelTuple>> readAllTuples(@Nullable Integer pageSize) {
-        return collectAllPages(pageSize, this::readTuples);
+        return readAllTuples(ReadTuplesFilter.ALL, pageSize, ReadTuplesOptions.DEFAULT);
+    }
+
+    /**
+     * Reads all tuples matching a filter.
+     *
+     * @param filter tuple filter
+     * @return all matching tuples
+     */
+    public Uni<List<RelTuple>> readAllTuples(ReadTuplesFilter filter) {
+        return readAllTuples(filter, null, ReadTuplesOptions.DEFAULT);
+    }
+
+    /**
+     * Reads all tuples matching a filter using the supplied page size and options.
+     *
+     * @param filter tuple filter
+     * @param pageSize page size, or {@code null} for the default
+     * @param options read options
+     * @return all matching tuples
+     */
+    public Uni<List<RelTuple>> readAllTuples(ReadTuplesFilter filter, @Nullable Integer pageSize,
+            ReadTuplesOptions options) {
+        return collectAllPages(pageSize, pagination -> readTuples(filter, pagination, options));
     }
 
     public AuthorizationModelsClient authorizationModels() {

--- a/runtime/src/main/java/io/quarkiverse/openfga/client/api/API.java
+++ b/runtime/src/main/java/io/quarkiverse/openfga/client/api/API.java
@@ -10,8 +10,10 @@ import static java.lang.String.format;
 import java.io.Closeable;
 import java.security.SecureRandom;
 import java.time.Clock;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.Nullable;
 
@@ -26,6 +28,7 @@ import io.quarkiverse.openfga.client.model.utils.ModelMapper;
 import io.quarkiverse.openfga.runtime.config.OpenFGAConfig;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.tls.TlsConfigurationRegistry;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
@@ -33,6 +36,8 @@ import io.vertx.core.http.RequestOptions;
 import io.vertx.core.impl.NoStackTraceThrowable;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.core.parsetools.JsonEvent;
+import io.vertx.mutiny.core.parsetools.JsonParser;
 import io.vertx.mutiny.ext.web.client.HttpRequest;
 import io.vertx.mutiny.ext.web.client.HttpResponse;
 import io.vertx.mutiny.ext.web.client.WebClient;
@@ -264,6 +269,41 @@ public class API implements Closeable {
                 ListObjectsResponse.class);
     }
 
+    /**
+     * Streams objects matching a List Objects request as OpenFGA produces them.
+     *
+     * @param storeId store identifier
+     * @param request list objects request
+     * @return streamed object responses
+     */
+    public Multi<StreamedListObjectsResponse> streamedListObjects(String storeId, ListObjectsRequest request) {
+        return Multi.createFrom().deferred(() -> {
+            var errorBody = new AtomicReference<String>();
+            var parser = JsonParser.newParser().objectValueMode();
+            var streamedResponses = parser.toMulti()
+                    .onItem().transformToMultiAndConcatenate(event -> decodeStreamedListObjects(event, errorBody));
+            var completedRequest = serialize(request)
+                    .onItem().transformToUni(body -> prepare(request("Streamed List Objects",
+                            POST,
+                            STREAMED_LIST_OBJECTS_URI,
+                            vars(STORE_ID_PARAM, storeId)).as(BodyCodec.jsonStream(parser)))
+                            .flatMap(preparedRequest -> preparedRequest
+                                    .putHeader(ACCEPT.toString(), APPLICATION_JSON)
+                                    .putHeader(CONTENT_TYPE.toString(), APPLICATION_JSON)
+                                    .sendBuffer(body)))
+                    .onItem().transformToMulti(response -> {
+                        try {
+                            checkStatus(response, ExpectedStatus.OK, errorBody.get());
+                            checkJSON(response);
+                            return Multi.createFrom().<StreamedListObjectsResponse> empty();
+                        } catch (Throwable error) {
+                            return Multi.createFrom().failure(error);
+                        }
+                    });
+            return Multi.createBy().merging().streams(streamedResponses, completedRequest);
+        });
+    }
+
     public Uni<ListUsersResponse> listUsers(String storeId, ListUsersRequest request) {
         return execute(
                 request("List Users",
@@ -285,14 +325,36 @@ public class API implements Closeable {
                 ReadAssertionsResponse.class);
     }
 
-    public Uni<Void> writeAssertions(String storeId, WriteAssertionsRequest request) {
+    /**
+     * Writes assertions for an authorization model.
+     *
+     * @param storeId store identifier
+     * @param authorizationModelId authorization model identifier
+     * @param request assertions request
+     * @return completion signal
+     */
+    public Uni<Void> writeAssertions(String storeId, String authorizationModelId, WriteAssertionsRequest request) {
         return execute(
                 request("Write Assertions",
                         PUT,
                         ASSERTIONS_URI,
-                        vars(STORE_ID_PARAM, storeId, AUTH_MODEL_ID_PARAM, request.getAuthorizationModelId())),
+                        vars(STORE_ID_PARAM, storeId, AUTH_MODEL_ID_PARAM, authorizationModelId)),
                 request,
                 ExpectedStatus.NO_CONTENT);
+    }
+
+    /**
+     * Writes assertions using the authorization model ID retained in the compatibility request shape.
+     *
+     * @param storeId store identifier
+     * @param request assertions request
+     * @return completion signal
+     * @deprecated use {@link #writeAssertions(String, String, WriteAssertionsRequest)}
+     */
+    @Deprecated(since = "3.15", forRemoval = true)
+    @SuppressWarnings("removal")
+    public Uni<Void> writeAssertions(String storeId, WriteAssertionsRequest request) {
+        return writeAssertions(storeId, request.getAuthorizationModelId(), request);
     }
 
     public Uni<HealthzResponse> health() {
@@ -395,18 +457,49 @@ public class API implements Closeable {
         return webClient.request(method, options);
     }
 
-    private static void checkJSONResponse(HttpResponse<Buffer> response, ExpectedStatus expectedStatus) throws Throwable {
+    private static Multi<StreamedListObjectsResponse> decodeStreamedListObjects(JsonEvent event,
+            AtomicReference<String> errorBody) {
+        try {
+            var value = event.objectValue();
+            if (value.containsKey("result")) {
+                var response = ModelMapper.mapper.readValue(value.getJsonObject("result").encode(),
+                        StreamedListObjectsResponse.class);
+                return Multi.createFrom().item(response);
+            }
+            if (value.containsKey("error")) {
+                var error = value.getJsonObject("error");
+                var details = error.getJsonArray("details");
+                List<Map<String, Object>> mappedDetails = details == null ? List.of()
+                        : details.stream().map(detail -> ((io.vertx.core.json.JsonObject) detail).getMap()).toList();
+                return Multi.createFrom().failure(new io.quarkiverse.openfga.client.model.FGAStreamException(
+                        error.getInteger("code"), error.getString("message"), mappedDetails));
+            }
+            errorBody.set(value.encode());
+            return Multi.createFrom().empty();
+        } catch (Throwable error) {
+            return Multi.createFrom().failure(error);
+        }
+    }
+
+    private static void checkJSONResponse(HttpResponse<?> response, ExpectedStatus expectedStatus) throws Throwable {
         checkStatus(response, expectedStatus);
         checkJSON(response);
     }
 
-    private static void checkStatus(HttpResponse<Buffer> response, ExpectedStatus expectedStatus) throws Throwable {
+    private static void checkStatus(HttpResponse<?> response, ExpectedStatus expectedStatus) throws Throwable {
         if (response.statusCode() != expectedStatus.statusCode) {
             throw Errors.convert(response);
         }
     }
 
-    private static void checkJSON(HttpResponse<Buffer> response) throws Throwable {
+    private static void checkStatus(HttpResponse<?> response, ExpectedStatus expectedStatus, @Nullable String body)
+            throws Throwable {
+        if (response.statusCode() != expectedStatus.statusCode) {
+            throw Errors.convert(response.statusCode(), body);
+        }
+    }
+
+    private static void checkJSON(HttpResponse<?> response) throws Throwable {
         String contentType = response.headers().get(HttpHeaders.CONTENT_TYPE);
         if (contentType == null) {
             throw new NoStackTraceThrowable("Missing response content type");
@@ -444,6 +537,8 @@ public class API implements Closeable {
     private static final UriTemplate BATCH_CHECK_URI = UriTemplate.of("/stores/{store_id}/batch-check");
     private static final UriTemplate EXPAND_URI = UriTemplate.of("/stores/{store_id}/expand");
     private static final UriTemplate LIST_OBJECTS_URI = UriTemplate.of("/stores/{store_id}/list-objects");
+    private static final UriTemplate STREAMED_LIST_OBJECTS_URI = UriTemplate
+            .of("/stores/{store_id}/streamed-list-objects");
     private static final UriTemplate LIST_USERS_URI = UriTemplate.of("/stores/{store_id}/list-users");
     private static final UriTemplate READ_URI = UriTemplate.of("/stores/{store_id}/read");
     private static final UriTemplate WRITE_URI = UriTemplate.of("/stores/{store_id}/write");

--- a/runtime/src/main/java/io/quarkiverse/openfga/client/api/Errors.java
+++ b/runtime/src/main/java/io/quarkiverse/openfga/client/api/Errors.java
@@ -1,38 +1,27 @@
 package io.quarkiverse.openfga.client.api;
 
 import io.quarkiverse.openfga.client.model.*;
+import io.quarkiverse.openfga.client.model.utils.ModelMapper;
 import io.vertx.mutiny.ext.web.client.HttpResponse;
 
 class Errors {
 
     static Throwable convert(HttpResponse<?> response) {
-        return switch (response.statusCode()) {
-            case 400 -> convertToValidationException(response);
-            case 401, 403 -> convertToAuthException(response);
-            case 404 -> convertToNotFoundException(response);
-            case 422 -> convertToUnprocessableContentException(response);
-            case 409, 500 -> convertToInternalException(response);
-            default -> new FGAUnknownException();
-        };
+        return convert(response.statusCode(), response.bodyAsString());
     }
 
-    private static FGAAuthException convertToAuthException(HttpResponse<?> response) {
-        return response.bodyAsJson(FGAAuthException.class);
-    }
-
-    private static FGAValidationException convertToValidationException(HttpResponse<?> response) {
-        return response.bodyAsJson(FGAValidationException.class);
-    }
-
-    private static FGANotFoundException convertToNotFoundException(HttpResponse<?> response) {
-        return response.bodyAsJson(FGANotFoundException.class);
-    }
-
-    private static FGAInternalException convertToInternalException(HttpResponse<?> response) {
-        return response.bodyAsJson(FGAInternalException.class);
-    }
-
-    private static FGAUnprocessableContentException convertToUnprocessableContentException(HttpResponse<?> response) {
-        return response.bodyAsJson(FGAUnprocessableContentException.class);
+    static Throwable convert(int statusCode, String body) {
+        try {
+            return switch (statusCode) {
+                case 400 -> ModelMapper.mapper.readValue(body, FGAValidationException.class);
+                case 401, 403 -> ModelMapper.mapper.readValue(body, FGAAuthException.class);
+                case 404 -> ModelMapper.mapper.readValue(body, FGANotFoundException.class);
+                case 422 -> ModelMapper.mapper.readValue(body, FGAUnprocessableContentException.class);
+                case 409, 500 -> ModelMapper.mapper.readValue(body, FGAInternalException.class);
+                default -> new FGAUnknownException();
+            };
+        } catch (Throwable ignored) {
+            return new FGAUnknownException();
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add OpenFGA API 3.15 models, request serializers, conflict behavior, and streaming support
- Extend assertions, authorization model, store, and core API clients
- Update Dev Services configuration, documentation, dependency metadata, and wire-contract coverage
- Add and update client integration tests for the expanded API surface

## Testing

- Not run (not requested)